### PR TITLE
Support resuming transactions / v0.6.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,13 +32,13 @@ jobs:
         include:
           - sqlite_version: "3420000"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
-            dart_sdk: 3.0.6
+            dart_sdk: 3.2.4
           - sqlite_version: "3410100"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz"
-            dart_sdk: 2.19.1
+            dart_sdk: 3.2.4
           - sqlite_version: "3380000"
             sqlite_url: "https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz"
-            dart_sdk: 2.19.1
+            dart_sdk: 3.2.0
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - sqlite_version: "3440200"
+            sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3440200.tar.gz"
+            dart_sdk: 3.2.4
+          - sqlite_version: "3430200"
+            sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3430200.tar.gz"
+            dart_sdk: 3.2.4
           - sqlite_version: "3420000"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
             dart_sdk: 3.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.0
+
+- Allow catching errors and continuing the transaction. This is technically a breaking change, although it should not be an issue in most cases.
+- Add `tx.closed` and `db/tx.getAutoCommit()` to check whether transactions are active.
+- Requires sqlite3 ^2.3.0 and Dart ^3.2.0.
+
 ## 0.5.2
 
 - Fix releasing of locks when closing `SharedMutex``.

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -49,9 +49,13 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
       : _writeConnection = writeConnection,
         _upstreamPort = upstreamPort;
 
+  /// Returns true if the _write_ connection is currently in autocommit mode.
   @override
-  Future<bool> isOpen() async {
-    return !closed;
+  Future<bool> getAutoCommit() async {
+    if (_writeConnection == null) {
+      throw AssertionError('Closed');
+    }
+    return await _writeConnection!.getAutoCommit();
   }
 
   @override

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -50,6 +50,11 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
         _upstreamPort = upstreamPort;
 
   @override
+  Future<bool> isOpen() async {
+    return !closed;
+  }
+
+  @override
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) async {
     await _expandPool();

--- a/lib/src/port_channel.dart
+++ b/lib/src/port_channel.dart
@@ -286,7 +286,7 @@ class _PortChannelResult<T> {
       return _result as T;
     } else {
       if (_error != null && stackTrace != null) {
-        Error.throwWithStackTrace(_error!, stackTrace!);
+        Error.throwWithStackTrace(_error, stackTrace!);
       } else {
         throw _error!;
       }

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -13,6 +13,15 @@ abstract class SqliteReadContext {
   Future<sqlite.Row?> getOptional(String sql,
       [List<Object?> parameters = const []]);
 
+  /// For transactions, returns true if the transaction is open.
+  ///
+  /// This means the lock is still held, and the transaction has not been committed
+  /// or rolled back (whether explicit rollback, or because of an error).
+  ///
+  /// For database connections, returns true if the connection hasn't been closed
+  /// yet.
+  Future<bool> isOpen();
+
   /// Run a function within a database isolate, with direct synchronous access
   /// to the underlying database.
   ///

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -13,14 +13,17 @@ abstract class SqliteReadContext {
   Future<sqlite.Row?> getOptional(String sql,
       [List<Object?> parameters = const []]);
 
-  /// For transactions, returns true if the transaction is open.
-  ///
-  /// This means the lock is still held, and the transaction has not been committed
-  /// or rolled back (whether explicit rollback, or because of an error).
+  /// For transactions, returns true if the lock is held (even if it has been
+  /// rolled back).
   ///
   /// For database connections, returns true if the connection hasn't been closed
   /// yet.
-  Future<bool> isOpen();
+  bool get closed;
+
+  /// Returns true if auto-commit is enabled. This means the database is not
+  /// currently in a transaction. This may be true even if a transaction lock
+  /// is still held, when the transaction has been committed or rolled back.
+  Future<bool> getAutoCommit();
 
   /// Run a function within a database isolate, with direct synchronous access
   /// to the underlying database.
@@ -114,5 +117,6 @@ abstract class SqliteConnection extends SqliteWriteContext {
   Future<void> close();
 
   /// Returns true if the connection is closed
+  @override
   bool get closed;
 }

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -49,6 +49,11 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
     return _isolateClient.closed;
   }
 
+  @override
+  Future<bool> isOpen() async {
+    return !closed;
+  }
+
   Future<void> _open(SqliteOpenFactory openFactory,
       {required bool primary,
       required SerializedPortClient upstreamPort}) async {
@@ -174,6 +179,13 @@ class _TransactionContext implements SqliteWriteContext {
         rethrow;
       }
     }
+  }
+
+  @override
+  Future<bool> isOpen() {
+    return computeWithDatabase((db) async {
+      return !db.autocommit;
+    });
   }
 
   @override

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -109,6 +109,11 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
     return _pool.closed;
   }
 
+  @override
+  Future<bool> isOpen() async {
+    return !closed;
+  }
+
   void _listenForEvents() {
     UpdateNotification? updates;
 

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -109,9 +109,11 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
     return _pool.closed;
   }
 
+  /// Returns true if the _write_ connection is in auto-commit mode
+  /// (no active transaction).
   @override
-  Future<bool> isOpen() async {
-    return !closed;
+  Future<bool> getAutoCommit() {
+    return _pool.getAutoCommit();
   }
 
   void _listenForEvents() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.5.2
-repository: https://github.com/journeyapps/sqlite_async.dart
+version: 0.6.0
+repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.19.1 <4.0.0'
 
 dependencies:
-  sqlite3: '>=1.10.1 <3.0.0'
+  sqlite3: '^2.3.0'
   async: ^2.10.0
   collection: ^1.17.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: High-performance asynchronous interface for SQLite on Dart and Flut
 version: 0.5.2
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
-  sdk: '>=2.19.1 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
   sqlite3: '^2.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   collection: ^1.17.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0
-  test_api: ^0.4.18
+  test_api: ^0.7.0
   glob: ^2.1.1
   benchmarking: ^0.6.1

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -228,7 +228,7 @@ void main() {
         await tx.execute(
             'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
             [2, 'test2']);
-        expect(await tx.isOpen(), equals(true));
+        expect(await tx.getAutoCommit(), equals(false));
         try {
           await tx.execute(
               'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
@@ -236,7 +236,8 @@ void main() {
         } catch (e) {
           // Ignore
         }
-        expect(await tx.isOpen(), equals(false));
+        expect(await tx.getAutoCommit(), equals(true));
+        expect(tx.closed, equals(false));
 
         // Will not be executed because of the above rollback
         ignore(tx.execute(
@@ -356,14 +357,16 @@ void main() {
         }
         expect(caught, equals(true));
 
-        expect(await tx.isOpen(), equals(true));
+        expect(await tx.getAutoCommit(), equals(false));
+        expect(tx.closed, equals(false));
 
         final rs = await tx.execute(
             'INSERT INTO test_data(description) VALUES(?) RETURNING description',
             ['Test Data']);
         expect(rs.rows[0], equals(['Test Data']));
       });
-      expect(await savedTx!.isOpen(), equals(false));
+      expect(await savedTx!.getAutoCommit(), equals(true));
+      expect(savedTx!.closed, equals(true));
     });
   });
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -222,18 +222,30 @@ void main() {
       await createTables(db);
 
       var tp = db.writeTransaction((tx) async {
-        tx.execute('INSERT INTO test_data(description) VALUES(?)', ['test1']);
-        tx.execute('INSERT INTO test_data(description) VALUES(?)', ['test2']);
-        ignore(tx.execute('INSERT INTO test_data(description) VALUES(json(?))',
-            ['test3'])); // Errors
-        // Will not be executed because of the above error
+        tx.execute(
+            'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
+            [1, 'test1']);
+        tx.execute(
+            'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
+            [2, 'test2']);
         ignore(tx.execute(
-            'INSERT INTO test_data(description) VALUES(?) RETURNING *',
-            ['test4']));
+            'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
+            [2, 'test3'])); // Errors
+
+        // Will not be executed because of the above rollback
+        ignore(tx.execute(
+            'INSERT OR ROLLBACK INTO test_data(id, description) VALUES(?, ?)',
+            [4, 'test4']));
       });
 
       // The error propagates up to the transaction
-      await expectLater(tp, throwsA((e) => e is sqlite.SqliteException));
+      await expectLater(
+          tp,
+          throwsA((e) =>
+              e is sqlite.SqliteException &&
+              e.message
+                  .contains('Transaction rolled back by earlier statement') &&
+              e.message.contains('UNIQUE constraint failed')));
 
       expect(await db.get('SELECT count() count FROM test_data'),
           equals({'count': 0}));
@@ -320,6 +332,27 @@ void main() {
         });
       });
       expect(computed, equals(5));
+    });
+
+    test('should allow resuming transaction after errors', () async {
+      final db = await setupDatabase(path: path);
+      await createTables(db);
+      await db.writeTransaction((tx) async {
+        var caught = false;
+        try {
+          // This error does not rollback the transaction
+          await tx.execute('NOT A VALID STATEMENT');
+        } catch (e) {
+          // Ignore
+          caught = true;
+        }
+        expect(caught, equals(true));
+
+        final rs = await tx.execute(
+            'INSERT INTO test_data(description) VALUES(?) RETURNING description',
+            ['Test Data']);
+        expect(rs.rows[0], equals(['Test Data']));
+      });
     });
   });
 }


### PR DESCRIPTION
- Allow catching errors and continuing the transaction. This is technically a breaking change, although it should not be an issue in most cases. Fixes #21.
- Add `tx.closed` and `db/tx.getAutoCommit()` to check whether transactions are active.
- Requires sqlite3 ^2.3.0 and Dart ^3.2.0.

In some cases, a statement will automatically roll back a transaction, and catching the error won't allow resuming the remainder of the transaction. These errors include [SQLITE_FULL](https://www.sqlite.org/rescode.html#full), [SQLITE_IOERR](https://www.sqlite.org/rescode.html#ioerr), [SQLITE_NOMEM](https://www.sqlite.org/rescode.html#nomem), [SQLITE_BUSY](https://www.sqlite.org/rescode.html#busy), and [SQLITE_INTERRUPT](https://www.sqlite.org/rescode.html#interrupt), as well as constraint errors together with `ON CONFLICT ROLLBACK`, `INSERT OR ROLLBACK` or similar statements.

Side note: Test fails because of repository URL mismatch between this branch and `main`. This will be resolved once the PR is merged.