### PR TITLE
Use busy_timeout for better lock handling across Isolates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,19 +32,19 @@ jobs:
         include:
           - sqlite_version: "3440200"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3440200.tar.gz"
-            dart_sdk: 3.2.4
+            dart_sdk: 3.3.3
           - sqlite_version: "3430200"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3430200.tar.gz"
-            dart_sdk: 3.2.4
+            dart_sdk: 3.3.3
           - sqlite_version: "3420000"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
-            dart_sdk: 3.2.4
+            dart_sdk: 3.3.3
           - sqlite_version: "3410100"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz"
-            dart_sdk: 3.2.4
+            dart_sdk: 3.3.3
           - sqlite_version: "3380000"
             sqlite_url: "https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz"
-            dart_sdk: 3.2.0
+            dart_sdk: 3.3.3
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -84,7 +84,8 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Open a read-write transaction.
   ///
   /// This takes a global lock - only one write transaction can execute against
-  /// the database at a time.
+  /// the database at a time. This applies even when constructing separate
+  /// [SqliteDatabase] instances for the same database file.
   ///
   /// Statements within the transaction must be done on the provided
   /// [SqliteWriteContext] - attempting statements on the [SqliteConnection]
@@ -104,6 +105,9 @@ abstract class SqliteConnection extends SqliteWriteContext {
 
   /// Takes a read lock, without starting a transaction.
   ///
+  /// The lock only applies to a single [SqliteConnection], and multiple
+  /// connections may hold read locks at the same time.
+  ///
   /// In most cases, [readTransaction] should be used instead.
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
@@ -111,6 +115,10 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Takes a global lock, without starting a transaction.
   ///
   /// In most cases, [writeTransaction] should be used instead.
+  ///
+  /// The lock applies to all [SqliteConnection] instances for a [SqliteDatabase].
+  /// Locks for separate [SqliteDatabase] instances on the same database file
+  /// may be held concurrently.
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
 

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -123,30 +123,15 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   @override
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) async {
-    final stopWatch = lockTimeout == null ? null : (Stopwatch()..start());
     // Private lock to synchronize this with other statements on the same connection,
     // to ensure that transactions aren't interleaved.
     return await _connectionMutex.lock(() async {
-      Duration? innerTimeout;
-      if (lockTimeout != null && stopWatch != null) {
-        innerTimeout = lockTimeout - stopWatch.elapsed;
-        stopWatch.stop();
+      final ctx = _TransactionContext(_isolateClient);
+      try {
+        return await callback(ctx);
+      } finally {
+        await ctx.close();
       }
-      // DB lock so that only one write happens at a time
-      return await _writeMutex.lock(() async {
-        final ctx = _TransactionContext(_isolateClient);
-        try {
-          return await callback(ctx);
-        } finally {
-          await ctx.close();
-        }
-      }, timeout: innerTimeout).catchError((error, stackTrace) {
-        if (error is TimeoutException) {
-          return Future<T>.error(TimeoutException(
-              'Failed to acquire global write lock', lockTimeout));
-        }
-        return Future<T>.error(error, stackTrace);
-      });
     }, timeout: lockTimeout);
   }
 }

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -15,8 +15,10 @@ import 'update_notification.dart';
 
 /// A SQLite database instance.
 ///
-/// Use one instance per database file. If multiple instances are used, update
-/// notifications may not trigger, and calls may fail with "SQLITE_BUSY" errors.
+/// Use one instance per database file where feasible.
+///
+/// If multiple instances are used, update notifications will not be propagated between them.
+/// For update notifications across isolates, use [isolateConnectionFactory].
 class SqliteDatabase with SqliteQueries implements SqliteConnection {
   /// The maximum number of concurrent read transactions if not explicitly specified.
   static const int defaultMaxReaders = 5;

--- a/lib/src/sqlite_open_factory.dart
+++ b/lib/src/sqlite_open_factory.dart
@@ -29,9 +29,10 @@ class DefaultSqliteOpenFactory implements SqliteOpenFactory {
   List<String> pragmaStatements(SqliteOpenOptions options) {
     List<String> statements = [];
 
-    if (sqliteOptions.busyTimeout != null) {
+    if (sqliteOptions.lockTimeout != null) {
+      // May be replaced by a Dart-level retry mechanism in the future
       statements.add(
-          'PRAGMA busy_timeout = ${sqliteOptions.busyTimeout!.inMilliseconds}');
+          'PRAGMA busy_timeout = ${sqliteOptions.lockTimeout!.inMilliseconds}');
     }
 
     if (options.primaryConnection && sqliteOptions.journalMode != null) {

--- a/lib/src/sqlite_options.dart
+++ b/lib/src/sqlite_options.dart
@@ -11,15 +11,22 @@ class SqliteOptions {
   /// attempt to truncate the file afterwards.
   final int? journalSizeLimit;
 
+  /// Timeout waiting for locks to be released by other write connections.
+  /// Defaults to 30 seconds.
+  /// Set to 0 to fail immediately when the database is locked.
+  final Duration? busyTimeout;
+
   const SqliteOptions.defaults()
       : journalMode = SqliteJournalMode.wal,
         journalSizeLimit = 6 * 1024 * 1024, // 1.5x the default checkpoint size
-        synchronous = SqliteSynchronous.normal;
+        synchronous = SqliteSynchronous.normal,
+        busyTimeout = const Duration(seconds: 30);
 
   const SqliteOptions(
       {this.journalMode = SqliteJournalMode.wal,
       this.journalSizeLimit = 6 * 1024 * 1024,
-      this.synchronous = SqliteSynchronous.normal});
+      this.synchronous = SqliteSynchronous.normal,
+      this.busyTimeout = const Duration(seconds: 30)});
 }
 
 /// SQLite journal mode. Set on the primary connection.

--- a/lib/src/sqlite_options.dart
+++ b/lib/src/sqlite_options.dart
@@ -11,22 +11,22 @@ class SqliteOptions {
   /// attempt to truncate the file afterwards.
   final int? journalSizeLimit;
 
-  /// Timeout waiting for locks to be released by other write connections.
+  /// Timeout waiting for locks to be released by other connections.
   /// Defaults to 30 seconds.
-  /// Set to 0 to fail immediately when the database is locked.
-  final Duration? busyTimeout;
+  /// Set to null or [Duration.zero] to fail immediately when the database is locked.
+  final Duration? lockTimeout;
 
   const SqliteOptions.defaults()
       : journalMode = SqliteJournalMode.wal,
         journalSizeLimit = 6 * 1024 * 1024, // 1.5x the default checkpoint size
         synchronous = SqliteSynchronous.normal,
-        busyTimeout = const Duration(seconds: 30);
+        lockTimeout = const Duration(seconds: 30);
 
   const SqliteOptions(
       {this.journalMode = SqliteJournalMode.wal,
       this.journalSizeLimit = 6 * 1024 * 1024,
       this.synchronous = SqliteSynchronous.normal,
-      this.busyTimeout = const Duration(seconds: 30)});
+      this.lockTimeout = const Duration(seconds: 30)});
 }
 
 /// SQLite journal mode. Set on the primary connection.

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -64,6 +64,39 @@ void main() {
       }
     });
 
+    test('Concurrency 2', () async {
+      final db1 =
+          SqliteDatabase.withFactory(testFactory(path: path), maxReaders: 3);
+
+      final db2 =
+          SqliteDatabase.withFactory(testFactory(path: path), maxReaders: 3);
+      await db1.initialize();
+      await createTables(db1);
+      await db2.initialize();
+      print("${DateTime.now()} start");
+
+      var futures1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((i) {
+        return db1.execute(
+            "INSERT OR REPLACE INTO test_data(id, description) SELECT ? as i, test_sleep(?) || ' ' || test_connection_name() || ' 1 ' || datetime() as connection RETURNING *",
+            [
+              i,
+              5 + Random().nextInt(20)
+            ]).then((value) => print("${DateTime.now()} $value"));
+      }).toList();
+
+      var futures2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((i) {
+        return db2.execute(
+            "INSERT OR REPLACE INTO test_data(id, description) SELECT ? as i, test_sleep(?) || ' ' || test_connection_name() || ' 2 ' || datetime() as connection RETURNING *",
+            [
+              i,
+              5 + Random().nextInt(20)
+            ]).then((value) => print("${DateTime.now()} $value"));
+      }).toList();
+      await Future.wait(futures1);
+      await Future.wait(futures2);
+      print("${DateTime.now()} done");
+    });
+
     test('read-only transactions', () async {
       final db = await setupDatabase(path: path);
       await createTables(db);


### PR DESCRIPTION
While read statements can execute concurrently on multiple connections, write statements and transactions use an exclusive lock. Currently, a global database-level lock is maintained and exposed across isolates, but this requires explicitly passing an IsolateConnectionFactory across Isolates. This is fine when explicitly spawning a new Isolate to do background work from the main Isolate, but does not work when the Isolates are managed externally, for example when using [flutter_workmanager](https://github.com/fluttercommunity/flutter_workmanager).

This configures SQLite [busy_timeout](https://www.sqlite.org/pragma.html#pragma_busy_timeout) to 30 seconds to work around the issue. When another connection is locking the database, SQLite will retry until the timeout has been reached.

In principle that makes our own global mutex redundant, and removing it can give some performance gains. That will form a separate PR - see #35.