### PR TITLE
Deprecate global mutex

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,9 @@ jobs:
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
       - name: Lint
-        run: dart analyze
+        run: dart analyze lib test example
+      - name: Test Fixes
+        run: dart fix --compare-to-golden test_fixes
       - name: Publish dry-run
         run: dart pub publish --dry-run
       - name: Check publish score

--- a/example/basic_example.dart
+++ b/example/basic_example.dart
@@ -28,7 +28,7 @@ void main() async {
   // Combine multiple statements into a single write transaction for:
   // 1. Atomic persistence (all updates are either applied or rolled back).
   // 2. Improved throughput.
-  await db.writeTransaction((tx) async {
+  await db.transaction((tx) async {
     await tx.execute('INSERT INTO test_data(data) values(?)', ['Test3']);
     await tx.execute('INSERT INTO test_data(data) values(?)', ['Test4']);
   });

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,0 +1,55 @@
+# This provides automatic fixes of deprecations using `dart fix`.
+# See: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
+version: 1
+transforms:
+  - title: 'Rename writeLock to lock'
+    date: 2024-04-02
+    element:
+      uris: ['src/sqlite_connection.dart']
+      method: 'writeLock'
+      inClass: 'SqliteConnection'
+    changes:
+      - kind: 'rename'
+        newName: 'lock'
+  - title: 'Rename writeTransaction to transaction'
+    date: 2024-04-02
+    element:
+      uris: ['src/sqlite_connection.dart']
+      method: 'writeTransaction'
+      inClass: 'SqliteConnection'
+    changes:
+      - kind: 'rename'
+        newName: 'transaction'
+  - title: 'Rename writeLock to lock'
+    date: 2024-04-02
+    element:
+      uris: ['src/sqlite_database.dart']
+      method: 'writeLock'
+      inClass: 'SqliteDatabase'
+    changes:
+      - kind: 'rename'
+        newName: 'lock'
+  - title: 'Rename writeTransaction to transaction'
+    date: 2024-04-02
+    element:
+      uris: ['src/sqlite_database.dart']
+      method: 'writeTransaction'
+      inClass: 'SqliteDatabase'
+    changes:
+      - kind: 'rename'
+        newName: 'transaction'
+  - title: 'Rename readTransaction to transaction'
+    date: 2024-04-02
+    element:
+      uris: ['src/sqlite_database.dart']
+      method: 'readTransaction'
+      inClass: 'SqliteDatabase'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'readOnly'
+        style: required_named
+        argumentValue:
+          expression: 'true'
+      - kind: 'rename'
+        newName: 'transaction'

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -160,8 +160,11 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
       return readLock((ctx) => callback(ctx as SqliteWriteContext),
           lockTimeout: lockTimeout, debugContext: debugContext);
     } else {
+      // FIXME:
+      // This should avoid using global locks, but then we need to fix
+      // update notifications to only fire after commit.
       return _writeLock(callback,
-          lockTimeout: lockTimeout, debugContext: debugContext, global: false);
+          lockTimeout: lockTimeout, debugContext: debugContext, global: true);
     }
   }
 

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -10,7 +10,7 @@ import 'update_notification.dart';
 
 /// A connection pool with a single write connection and multiple read connections.
 class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
-  SqliteConnection? _writeConnection;
+  SqliteConnectionImpl? _writeConnection;
 
   final List<SqliteConnectionImpl> _readConnections = [];
 
@@ -42,7 +42,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   SqliteConnectionPool(this._factory,
       {this.updates,
       this.maxReaders = 5,
-      SqliteConnection? writeConnection,
+      SqliteConnectionImpl? writeConnection,
       this.debugName,
       required this.mutex,
       required SerializedPortClient upstreamPort})
@@ -72,7 +72,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
           _readConnections.remove(connection);
         }
         try {
-          return await connection.readLock((ctx) async {
+          return await connection.lock((ctx) async {
             if (haveLock) {
               // Already have a different lock - release this one.
               return false;
@@ -91,7 +91,10 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
             }
 
             return true;
-          }, lockTimeout: lockTimeout, debugContext: debugContext);
+          },
+              lockTimeout: lockTimeout,
+              readOnly: true,
+              debugContext: debugContext);
         } on TimeoutException {
           return false;
         }
@@ -117,6 +120,12 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   @override
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) {
+    return _writeLock(callback,
+        lockTimeout: lockTimeout, debugContext: debugContext, global: true);
+  }
+
+  Future<T> _writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {Duration? lockTimeout, String? debugContext, required bool global}) {
     if (closed) {
       throw AssertionError('Closed');
     }
@@ -132,10 +141,28 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
         readOnly: false,
         openFactory: _factory);
     return _runZoned(() {
-      // ignore: deprecated_member_use_from_same_package
-      return _writeConnection!.writeLock(callback,
-          lockTimeout: lockTimeout, debugContext: debugContext);
+      if (global) {
+        // ignore: deprecated_member_use_from_same_package
+        return _writeConnection!.writeLock(callback,
+            lockTimeout: lockTimeout, debugContext: debugContext);
+      } else {
+        return _writeConnection!.lock(callback,
+            lockTimeout: lockTimeout, debugContext: debugContext);
+      }
     }, debugContext: debugContext ?? 'execute()');
+  }
+
+  @override
+  Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {bool? readOnly, Duration? lockTimeout, String? debugContext}) {
+    if (readOnly == true) {
+      // ignore: deprecated_member_use_from_same_package
+      return readLock((ctx) => callback(ctx as SqliteWriteContext),
+          lockTimeout: lockTimeout, debugContext: debugContext);
+    } else {
+      return _writeLock(callback,
+          lockTimeout: lockTimeout, debugContext: debugContext, global: false);
+    }
   }
 
   /// The [Mutex] on individual connections do already error in recursive locks.

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -132,6 +132,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
         readOnly: false,
         openFactory: _factory);
     return _runZoned(() {
+      // ignore: deprecated_member_use_from_same_package
       return _writeConnection!.writeLock(callback,
           lockTimeout: lockTimeout, debugContext: debugContext);
     }, debugContext: debugContext ?? 'execute()');

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -82,16 +82,18 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Statements within the transaction must be done on the provided
   /// [SqliteWriteContext] - attempting statements on the [SqliteConnection]
   /// instance will error.
+  ///
+  /// [lockTimeout] only controls the timeout for locking the connection.
+  /// Timeout for database-level locks can be configured on [SqliteOpenOptions].
   Future<T> transaction<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {bool? readOnly});
+      {bool? readOnly, Duration? lockTimeout});
 
   /// Open a read-only transaction.
   ///
   /// Statements within the transaction must be done on the provided
   /// [SqliteReadContext] - attempting statements on the [SqliteConnection]
   /// instance will error.
-  @Deprecated(
-      'Use [transaction(callback)] instead, and set lockTimeout on [SqliteOpenOptions].')
+  @Deprecated('Use [transaction(callback)] instead.')
   Future<T> readTransaction<T>(
       Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout});
@@ -104,8 +106,7 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Statements within the transaction must be done on the provided
   /// [SqliteWriteContext] - attempting statements on the [SqliteConnection]
   /// instance will error.
-  @Deprecated(
-      'Use [transaction(callback)] instead, and set lockTimeout on [SqliteOpenOptions].')
+  @Deprecated('Use [transaction(callback)] instead.')
   Future<T> writeTransaction<T>(
       Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout});
@@ -122,14 +123,14 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Takes a read lock on this connection, without starting a transaction.
   ///
   /// This is a low-level API. In most cases, [transaction] should be used instead.
-  @Deprecated('Use [lock] instead, and set lockTimeout on [SqliteOpenOptions].')
+  @Deprecated('Use [lock] instead.')
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
 
   /// Takes a global write lock, without starting a transaction.
   ///
   /// This is a low-level API. In most cases, [transaction] should be used instead.
-  @Deprecated('Use [lock] instead, and set lockTimeout on [SqliteOpenOptions].')
+  @Deprecated('Use [lock] instead.')
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
 
@@ -142,7 +143,7 @@ abstract class SqliteConnection extends SqliteWriteContext {
   ///
   /// Any direct query methods such as [getAll] or [execute] uses [lock] internally.
   Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {bool? readOnly, String? debugContext});
+      {bool? readOnly, Duration? lockTimeout, String? debugContext});
 
   Future<void> close();
 

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -72,11 +72,26 @@ abstract class SqliteWriteContext extends SqliteReadContext {
 
 /// Abstract class representing a connection to the SQLite database.
 abstract class SqliteConnection extends SqliteWriteContext {
+  /// Open a transaction.
+  ///
+  /// Opens a read-write transaction by default. Set [readOnly] to open a
+  /// read-only transaction.
+  ///
+  /// Only one read-write transaction can execute against the database at a time.
+  ///
+  /// Statements within the transaction must be done on the provided
+  /// [SqliteWriteContext] - attempting statements on the [SqliteConnection]
+  /// instance will error.
+  Future<T> transaction<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {bool? readOnly});
+
   /// Open a read-only transaction.
   ///
   /// Statements within the transaction must be done on the provided
   /// [SqliteReadContext] - attempting statements on the [SqliteConnection]
   /// instance will error.
+  @Deprecated(
+      'Use [transaction(callback)] instead, and set lockTimeout on [SqliteOpenOptions].')
   Future<T> readTransaction<T>(
       Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout});
@@ -89,6 +104,8 @@ abstract class SqliteConnection extends SqliteWriteContext {
   /// Statements within the transaction must be done on the provided
   /// [SqliteWriteContext] - attempting statements on the [SqliteConnection]
   /// instance will error.
+  @Deprecated(
+      'Use [transaction(callback)] instead, and set lockTimeout on [SqliteOpenOptions].')
   Future<T> writeTransaction<T>(
       Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout});
@@ -102,17 +119,30 @@ abstract class SqliteConnection extends SqliteWriteContext {
       {List<Object?> parameters = const [],
       Duration throttle = const Duration(milliseconds: 30)});
 
-  /// Takes a read lock, without starting a transaction.
+  /// Takes a read lock on this connection, without starting a transaction.
   ///
-  /// In most cases, [readTransaction] should be used instead.
+  /// This is a low-level API. In most cases, [transaction] should be used instead.
+  @Deprecated('Use [lock] instead, and set lockTimeout on [SqliteOpenOptions].')
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
 
-  /// Takes a global lock, without starting a transaction.
+  /// Takes a global write lock, without starting a transaction.
   ///
-  /// In most cases, [writeTransaction] should be used instead.
+  /// This is a low-level API. In most cases, [transaction] should be used instead.
+  @Deprecated('Use [lock] instead, and set lockTimeout on [SqliteOpenOptions].')
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext});
+
+  /// Lock a connection for exclusive usage.
+  ///
+  /// When using a connection pool, use [readOnly] to select a read connection.
+  /// In other contexts, [readOnly] has no effect.
+  ///
+  /// This is a low-level API. In most cases, [transaction] should be used instead.
+  ///
+  /// Any direct query methods such as [getAll] or [execute] uses [lock] internally.
+  Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {bool? readOnly, String? debugContext});
 
   Future<void> close();
 

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -106,21 +106,6 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   }
 
   @override
-  Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {bool? readOnly, Duration? lockTimeout, String? debugContext}) async {
-    // Private lock to synchronize this with other statements on the same connection,
-    // to ensure that transactions aren't interleaved.
-    return _connectionMutex.lock(() async {
-      final ctx = _TransactionContext(_isolateClient);
-      try {
-        return await callback(ctx);
-      } finally {
-        await ctx.close();
-      }
-    }, timeout: lockTimeout);
-  }
-
-  @override
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) async {
     return lock(callback, lockTimeout: lockTimeout, debugContext: debugContext);

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -123,30 +123,15 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   @override
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) async {
-    final stopWatch = lockTimeout == null ? null : (Stopwatch()..start());
     // Private lock to synchronize this with other statements on the same connection,
     // to ensure that transactions aren't interleaved.
     return await _connectionMutex.lock(() async {
-      Duration? innerTimeout;
-      if (lockTimeout != null && stopWatch != null) {
-        innerTimeout = lockTimeout - stopWatch.elapsed;
-        stopWatch.stop();
+      final ctx = _TransactionContext(_isolateClient);
+      try {
+        return await callback(ctx);
+      } finally {
+        await ctx.close();
       }
-      // DB lock so that only one write happens at a time
-      return await _writeMutex.lock(() async {
-        final ctx = _TransactionContext(_isolateClient);
-        try {
-          return await callback(ctx);
-        } finally {
-          await ctx.close();
-        }
-      }, timeout: innerTimeout).catchError((error, stackTrace) {
-        if (error is TimeoutException) {
-          return Future<T>.error(TimeoutException(
-              'Failed to acquire global write lock', lockTimeout));
-        }
-        return Future<T>.error(error, stackTrace);
-      });
     }, timeout: lockTimeout);
   }
 }

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -106,8 +106,8 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   }
 
   @override
-  Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
-      {Duration? lockTimeout, String? debugContext}) async {
+  Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {bool? readOnly, Duration? lockTimeout, String? debugContext}) async {
     // Private lock to synchronize this with other statements on the same connection,
     // to ensure that transactions aren't interleaved.
     return _connectionMutex.lock(() async {
@@ -118,6 +118,12 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
         await ctx.close();
       }
     }, timeout: lockTimeout);
+  }
+
+  @override
+  Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
+      {Duration? lockTimeout, String? debugContext}) async {
+    return lock(callback, lockTimeout: lockTimeout, debugContext: debugContext);
   }
 
   @override

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -199,10 +199,12 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
   /// Changes from any write transaction are not visible to read transactions
   /// started before it.
   @override
+  @Deprecated('Use [transaction] instead.')
   Future<T> readTransaction<T>(
       Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout}) {
-    return _pool.readTransaction(callback, lockTimeout: lockTimeout);
+    return _pool.transaction(callback,
+        readOnly: true, lockTimeout: lockTimeout);
   }
 
   /// Open a read-write transaction.
@@ -213,20 +215,23 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
   /// The write transaction is automatically committed when the callback finishes,
   /// or rolled back on any error.
   @override
+  @Deprecated('Use [transaction] instead.')
   Future<T> writeTransaction<T>(
       Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout}) {
-    return _pool.writeTransaction(callback, lockTimeout: lockTimeout);
+    return _pool.transaction(callback, lockTimeout: lockTimeout);
   }
 
   @override
+  @Deprecated('Use [lock] instead.')
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) {
-    return _pool.readLock(callback,
-        lockTimeout: lockTimeout, debugContext: debugContext);
+    return _pool.lock(callback,
+        readOnly: true, lockTimeout: lockTimeout, debugContext: debugContext);
   }
 
   @override
+  @Deprecated('Use [lock] instead.')
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) {
     return _pool.writeLock(callback,

--- a/lib/src/sqlite_migrations.dart
+++ b/lib/src/sqlite_migrations.dart
@@ -90,7 +90,7 @@ class SqliteMigrations {
   Future<void> migrate(SqliteConnection db) async {
     _validateCreateDatabase();
 
-    await db.writeTransaction((tx) async {
+    await db.transaction((tx) async {
       await tx.execute(
           'CREATE TABLE IF NOT EXISTS $migrationTable(id INTEGER PRIMARY KEY, down_migrations TEXT)');
 

--- a/lib/src/sqlite_open_factory.dart
+++ b/lib/src/sqlite_open_factory.dart
@@ -29,9 +29,10 @@ class DefaultSqliteOpenFactory implements SqliteOpenFactory {
   List<String> pragmaStatements(SqliteOpenOptions options) {
     List<String> statements = [];
 
-    if (sqliteOptions.busyTimeout != null) {
+    if (sqliteOptions.lockTimeout != null) {
+      // May be replaced by a Dart-level retry mechanism in the future
       statements.add(
-          'PRAGMA busy_timeout = ${sqliteOptions.busyTimeout!.inMilliseconds}');
+          'PRAGMA busy_timeout = ${sqliteOptions.lockTimeout!.inMilliseconds}');
     }
 
     if (options.primaryConnection && sqliteOptions.journalMode != null) {

--- a/lib/src/sqlite_options.dart
+++ b/lib/src/sqlite_options.dart
@@ -11,15 +11,22 @@ class SqliteOptions {
   /// attempt to truncate the file afterwards.
   final int? journalSizeLimit;
 
+  /// Timeout waiting for locks to be released by other write connections.
+  /// Defaults to 30 seconds.
+  /// Set to 0 to fail immediately when the database is locked.
+  final Duration? busyTimeout;
+
   const SqliteOptions.defaults()
       : journalMode = SqliteJournalMode.wal,
         journalSizeLimit = 6 * 1024 * 1024, // 1.5x the default checkpoint size
-        synchronous = SqliteSynchronous.normal;
+        synchronous = SqliteSynchronous.normal,
+        busyTimeout = const Duration(seconds: 30);
 
   const SqliteOptions(
       {this.journalMode = SqliteJournalMode.wal,
       this.journalSizeLimit = 6 * 1024 * 1024,
-      this.synchronous = SqliteSynchronous.normal});
+      this.synchronous = SqliteSynchronous.normal,
+      this.busyTimeout = const Duration(seconds: 30)});
 }
 
 /// SQLite journal mode. Set on the primary connection.

--- a/lib/src/sqlite_options.dart
+++ b/lib/src/sqlite_options.dart
@@ -11,22 +11,22 @@ class SqliteOptions {
   /// attempt to truncate the file afterwards.
   final int? journalSizeLimit;
 
-  /// Timeout waiting for locks to be released by other write connections.
+  /// Timeout waiting for locks to be released by other connections.
   /// Defaults to 30 seconds.
-  /// Set to 0 to fail immediately when the database is locked.
-  final Duration? busyTimeout;
+  /// Set to null or [Duration.zero] to fail immediately when the database is locked.
+  final Duration? lockTimeout;
 
   const SqliteOptions.defaults()
       : journalMode = SqliteJournalMode.wal,
         journalSizeLimit = 6 * 1024 * 1024, // 1.5x the default checkpoint size
         synchronous = SqliteSynchronous.normal,
-        busyTimeout = const Duration(seconds: 30);
+        lockTimeout = const Duration(seconds: 30);
 
   const SqliteOptions(
       {this.journalMode = SqliteJournalMode.wal,
       this.journalSizeLimit = 6 * 1024 * 1024,
       this.synchronous = SqliteSynchronous.normal,
-      this.busyTimeout = const Duration(seconds: 30)});
+      this.lockTimeout = const Duration(seconds: 30)});
 }
 
 /// SQLite journal mode. Set on the primary connection.

--- a/lib/src/sqlite_queries.dart
+++ b/lib/src/sqlite_queries.dart
@@ -144,26 +144,28 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
 
   @override
   Future<T> lock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {bool? readOnly, String? debugContext}) {
+      {bool? readOnly, Duration? lockTimeout, String? debugContext}) {
     if (readOnly == true) {
       // ignore: deprecated_member_use_from_same_package
       return readLock((ctx) => callback(ctx as SqliteWriteContext),
-          debugContext: debugContext);
+          lockTimeout: lockTimeout, debugContext: debugContext);
     } else {
       // ignore: deprecated_member_use_from_same_package
-      return writeLock(callback, debugContext: debugContext);
+      return writeLock(callback,
+          lockTimeout: lockTimeout, debugContext: debugContext);
     }
   }
 
   @override
   Future<T> transaction<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {bool? readOnly}) {
+      {bool? readOnly, Duration? lockTimeout}) {
     if (readOnly == true) {
       // ignore: deprecated_member_use_from_same_package
-      return readTransaction((ctx) => callback(ctx as SqliteWriteContext));
+      return readTransaction((ctx) => callback(ctx as SqliteWriteContext),
+          lockTimeout: lockTimeout);
     } else {
       // ignore: deprecated_member_use_from_same_package
-      return writeTransaction(callback);
+      return writeTransaction(callback, lockTimeout: lockTimeout);
     }
   }
 }

--- a/lib/src/sqlite_queries.dart
+++ b/lib/src/sqlite_queries.dart
@@ -164,6 +164,9 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       return readTransaction((ctx) => callback(ctx as SqliteWriteContext),
           lockTimeout: lockTimeout);
     } else {
+      // FIXME:
+      // This should avoid using global locks, but then we need to fix
+      // update notifications to only fire after commit.
       // ignore: deprecated_member_use_from_same_package
       return writeTransaction(callback, lockTimeout: lockTimeout);
     }

--- a/scripts/benchmark.dart
+++ b/scripts/benchmark.dart
@@ -46,14 +46,14 @@ List<SqliteBenchmark> benchmarks = [
       }
     });
   }, maxBatchSize: 200000, enabled: false),
-  SqliteBenchmark('writeLock in isolate',
+  SqliteBenchmark('lock in isolate',
       (SqliteDatabase db, List<List<String>> parameters) async {
     var factory = db.isolateConnectionFactory();
     var len = parameters.length;
     await Isolate.run(() async {
       final db = factory.open();
       for (var i = 0; i < len; i++) {
-        await db.writeLock((tx) async {});
+        await db.lock((tx) async {});
       }
       await db.close();
     });

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -64,6 +64,39 @@ void main() {
       }
     });
 
+    test('Concurrency 2', () async {
+      final db1 =
+          SqliteDatabase.withFactory(testFactory(path: path), maxReaders: 3);
+
+      final db2 =
+          SqliteDatabase.withFactory(testFactory(path: path), maxReaders: 3);
+      await db1.initialize();
+      await createTables(db1);
+      await db2.initialize();
+      print("${DateTime.now()} start");
+
+      var futures1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((i) {
+        return db1.execute(
+            "INSERT OR REPLACE INTO test_data(id, description) SELECT ? as i, test_sleep(?) || ' ' || test_connection_name() || ' 1 ' || datetime() as connection RETURNING *",
+            [
+              i,
+              5 + Random().nextInt(20)
+            ]).then((value) => print("${DateTime.now()} $value"));
+      }).toList();
+
+      var futures2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((i) {
+        return db2.execute(
+            "INSERT OR REPLACE INTO test_data(id, description) SELECT ? as i, test_sleep(?) || ' ' || test_connection_name() || ' 2 ' || datetime() as connection RETURNING *",
+            [
+              i,
+              5 + Random().nextInt(20)
+            ]).then((value) => print("${DateTime.now()} $value"));
+      }).toList();
+      await Future.wait(futures1);
+      await Future.wait(futures2);
+      print("${DateTime.now()} done");
+    });
+
     test('read-only transactions', () async {
       final db = await setupDatabase(path: path);
       await createTables(db);

--- a/test/close_test.dart
+++ b/test/close_test.dart
@@ -19,7 +19,7 @@ void main() {
     });
 
     createTables(SqliteDatabase db) async {
-      await db.writeTransaction((tx) async {
+      await db.transaction((tx) async {
         await tx.execute(
             'CREATE TABLE test_data(id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT)');
       });

--- a/test/json1_test.dart
+++ b/test/json1_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
 
     createTables(SqliteDatabase db) async {
-      await db.writeTransaction((tx) async {
+      await db.transaction((tx) async {
         await tx.execute(
             'CREATE TABLE users(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, email TEXT)');
       });

--- a/test/util.dart
+++ b/test/util.dart
@@ -9,8 +9,8 @@ import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
-// const defaultSqlitePath = 'libsqlite3.so.0';
-const defaultSqlitePath = './sqlite-autoconf-3410100/.libs/libsqlite3.so.0';
+const defaultSqlitePath = 'libsqlite3.so.0';
+// const defaultSqlitePath = './sqlite-autoconf-3410100/.libs/libsqlite3.so.0';
 
 class TestSqliteOpenFactory extends DefaultSqliteOpenFactory {
   String sqlitePath;

--- a/test/util.dart
+++ b/test/util.dart
@@ -9,8 +9,8 @@ import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
-const defaultSqlitePath = 'libsqlite3.so.0';
-// const defaultSqlitePath = './sqlite-autoconf-3410100/.libs/libsqlite3.so.0';
+// const defaultSqlitePath = 'libsqlite3.so.0';
+const defaultSqlitePath = './sqlite-autoconf-3410100/.libs/libsqlite3.so.0';
 
 class TestSqliteOpenFactory extends DefaultSqliteOpenFactory {
   String sqlitePath;

--- a/test/watch_test.dart
+++ b/test/watch_test.dart
@@ -11,7 +11,7 @@ import 'util.dart';
 
 void main() {
   createTables(SqliteDatabase db) async {
-    await db.writeTransaction((tx) async {
+    await db.transaction((tx) async {
       await tx.execute(
           'CREATE TABLE assets(id INTEGER PRIMARY KEY AUTOINCREMENT, make TEXT, customer_id INTEGER)');
       await tx.execute('CREATE INDEX assets_customer ON assets(customer_id)');

--- a/test_fixes/sqlite_database.dart
+++ b/test_fixes/sqlite_database.dart
@@ -1,0 +1,13 @@
+import 'package:sqlite_async/src/sqlite_database.dart';
+
+var db = SqliteDatabase(path: 'test.db');
+
+void main() async {
+  db.writeTransaction((tx) async {
+    await tx.execute('select 1');
+  });
+
+  db.readTransaction((tx) async {
+    await tx.getAll('select 1');
+  });
+}

--- a/test_fixes/sqlite_database.dart.expect
+++ b/test_fixes/sqlite_database.dart.expect
@@ -1,0 +1,13 @@
+import 'package:sqlite_async/src/sqlite_database.dart';
+
+var db = SqliteDatabase(path: 'test.db');
+
+void main() async {
+  db.transaction((tx) async {
+    await tx.execute('select 1');
+  });
+
+  db.transaction((tx) async {
+    await tx.getAll('select 1');
+  }, readOnly: true);
+}


### PR DESCRIPTION
Builds on #34.

Deprecates our global per-database mutex, instead relying on SQLite's built-in locking mechanism.

To avoid breaking changes, new `lock` and `transaction` methods are added, with the intention of not using our global mutex, as well as to simplify the APIs a little (most of the time only `writeTransaction` was used).

A final blocker to avoid using the global mutex is update notifications - currently the global mutex is used to ensure the notifications are only sent once the transaction did commit. This needs to be refactored to not rely on the mutex.

