### PR TITLE
Fix errors when closing

### DIFF
--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -94,6 +94,8 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
           }, lockTimeout: lockTimeout, debugContext: debugContext);
         } on TimeoutException {
           return false;
+        } on ClosedException {
+          return false;
         }
       });
 

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -158,7 +158,8 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     if (closed || _readConnections.length >= maxReaders) {
       return;
     }
-    bool hasCapacity = _readConnections.any((connection) => !connection.locked);
+    bool hasCapacity = _readConnections
+        .any((connection) => !connection.locked && !connection.closed);
     if (!hasCapacity) {
       var name = debugName == null
           ? null

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -53,7 +53,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   @override
   Future<bool> getAutoCommit() async {
     if (_writeConnection == null) {
-      throw AssertionError('Closed');
+      throw ClosedException();
     }
     return await _writeConnection!.getAutoCommit();
   }
@@ -118,7 +118,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) {
     if (closed) {
-      throw AssertionError('Closed');
+      throw ClosedException();
     }
     if (_writeConnection?.closed == true) {
       _writeConnection = null;

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -191,6 +191,9 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     // Create a copy of the list, to avoid this triggering "Concurrent modification during iteration"
     final toClose = _readConnections.sublist(0);
     for (var connection in toClose) {
+      // Wait for connection initialization, so that any existing readLock()
+      // requests go through before closing.
+      await connection.ready;
       await connection.close();
     }
     // Closing the write connection cleans up the journal files (-shm and -wal files).

--- a/lib/src/port_channel.dart
+++ b/lib/src/port_channel.dart
@@ -60,7 +60,6 @@ class ParentPortClient implements PortClient {
     });
     _errorPort.listen((message) {
       var [error, stackTrace] = message;
-      print('got an error ${initCompleter.isCompleted} $error');
       if (!initCompleter.isCompleted) {
         if (stackTrace == null) {
           initCompleter.completeError(error);

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -88,6 +88,9 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   @override
   Future<void> close() async {
     await _connectionMutex.lock(() async {
+      if (closed) {
+        return;
+      }
       if (readOnly) {
         await _isolateClient.post(const _SqliteIsolateConnectionClose());
       } else {
@@ -97,6 +100,7 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
           await _isolateClient.post(const _SqliteIsolateConnectionClose());
         });
       }
+      _isolateClient.close();
       _isolate.kill();
     });
   }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite_async.dart';
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -301,8 +302,11 @@ void main() {
       }).catchError((error) {
         caughtError = error;
       });
-      // This may change into a better error in the future
-      expect(caughtError.toString(), equals("Instance of 'ClosedException'"));
+      // The specific error message may change
+      expect(
+          caughtError.toString(),
+          equals(
+              "IsolateError in sqlite-writer: Invalid argument(s): uncaught async error"));
 
       // Check that we can still continue afterwards
       final computed = await db.computeWithDatabase((db) async {
@@ -328,8 +332,11 @@ void main() {
         }).catchError((error) {
           caughtError = error;
         });
-        // This may change into a better error in the future
-        expect(caughtError.toString(), equals("Instance of 'ClosedException'"));
+        // The specific message may change
+        expect(
+            caughtError.toString(),
+            matches(RegExp(
+                r'IsolateError in sqlite-\d+: Invalid argument\(s\): uncaught async error')));
       }
 
       // Check that we can still continue afterwards

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -383,6 +383,7 @@ void main() {
         // Second connection to sleep more than first connection
         'SELECT test_sleep(test_connection_number() * 10)'
       ]));
+      await db.initialize();
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -377,7 +377,6 @@ void main() {
       // 4. Now second connection is ready. Second query has two connections to choose from.
       // 5. However, first connection is closed, so it's removed from the pool.
       // 6. Triggers `Concurrent modification during iteration: Instance(length:1) of '_GrowableList'`
-
       final db =
           SqliteDatabase.withFactory(testFactory(path: path, initStatements: [
         // Second connection to sleep more than first connection
@@ -387,8 +386,9 @@ void main() {
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');
-      final closeFuture = db.close();
-      await closeFuture;
+
+      await db.close();
+
       await future1;
       await future2;
     });

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -383,7 +383,6 @@ void main() {
         // Second connection to sleep more than first connection
         'SELECT test_sleep(test_connection_number() * 10)'
       ]));
-      await createTables(db);
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');


### PR DESCRIPTION
Fixes #36.

Also improves handling of database initialization errors and other uncaught errors in connection isolates.

The new test currently often fails with this error:
```
SqliteException(261): while executing, database is locked, database is locked (code 261)
    Causing statement: PRAGMA synchronous = NORMAL, parameters: 
```

It is likely caused by opening multiple connections at the same time. #34 will fix the issue.

