### PR TITLE
Improve connection pool read performance

### DIFF
--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -94,6 +94,8 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
           }, lockTimeout: lockTimeout, debugContext: debugContext);
         } on TimeoutException {
           return false;
+        } on ClosedException {
+          return false;
         }
       });
 

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -158,7 +158,8 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     if (closed || _readConnections.length >= maxReaders) {
       return;
     }
-    bool hasCapacity = _readConnections.any((connection) => !connection.locked);
+    bool hasCapacity = _readConnections
+        .any((connection) => !connection.locked && !connection.closed);
     if (!hasCapacity) {
       var name = debugName == null
           ? null

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -53,7 +53,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   @override
   Future<bool> getAutoCommit() async {
     if (_writeConnection == null) {
-      throw AssertionError('Closed');
+      throw ClosedException();
     }
     return await _writeConnection!.getAutoCommit();
   }
@@ -118,7 +118,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) {
     if (closed) {
-      throw AssertionError('Closed');
+      throw ClosedException();
     }
     if (_writeConnection?.closed == true) {
       _writeConnection = null;

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -191,6 +191,9 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     // Create a copy of the list, to avoid this triggering "Concurrent modification during iteration"
     final toClose = _readConnections.sublist(0);
     for (var connection in toClose) {
+      // Wait for connection initialization, so that any existing readLock()
+      // requests go through before closing.
+      await connection.ready;
       await connection.close();
     }
     // Closing the write connection cleans up the journal files (-shm and -wal files).

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'mutex.dart';
 import 'port_channel.dart';
@@ -12,7 +13,9 @@ import 'update_notification.dart';
 class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   SqliteConnection? _writeConnection;
 
-  final List<SqliteConnectionImpl> _readConnections = [];
+  final Set<SqliteConnectionImpl> _allReadConnections = {};
+  final Queue<SqliteConnectionImpl> _availableReadConnections = Queue();
+  final Queue<_PendingItem> _queue = Queue();
 
   final SqliteOpenFactory _factory;
   final SerializedPortClient _upstreamPort;
@@ -58,62 +61,60 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     return await _writeConnection!.getAutoCommit();
   }
 
-  @override
-  Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
-      {Duration? lockTimeout, String? debugContext}) async {
-    await _expandPool();
-
-    return _runZoned(() async {
-      bool haveLock = false;
-      var completer = Completer<T>();
-
-      var futures = _readConnections.sublist(0).map((connection) async {
-        if (connection.closed) {
-          _readConnections.remove(connection);
-        }
-        try {
-          return await connection.readLock((ctx) async {
-            if (haveLock) {
-              // Already have a different lock - release this one.
-              return false;
-            }
-            haveLock = true;
-
-            var future = callback(ctx);
-            completer.complete(future);
-
-            // We have to wait for the future to complete before we can release the
-            // lock.
-            try {
-              await future;
-            } catch (_) {
-              // Ignore
-            }
-
-            return true;
-          }, lockTimeout: lockTimeout, debugContext: debugContext);
-        } on TimeoutException {
-          return false;
-        } on ClosedException {
-          return false;
-        }
-      });
-
-      final stream = Stream<bool>.fromFutures(futures);
-      var gotAny = await stream.any((element) => element);
-
-      if (!gotAny) {
-        // All TimeoutExceptions
-        throw TimeoutException('Failed to get a read connection', lockTimeout);
+  void _nextRead() {
+    if (_queue.isEmpty) {
+      // Wait for queue item
+      return;
+    } else if (closed) {
+      while (_queue.isNotEmpty) {
+        final nextItem = _queue.removeFirst();
+        nextItem.completer.completeError(const ClosedException());
       }
+      return;
+    }
 
+    while (_availableReadConnections.isNotEmpty &&
+        _availableReadConnections.last.closed) {
+      // Remove connections that may have errored
+      final connection = _availableReadConnections.removeLast();
+      _allReadConnections.remove(connection);
+    }
+
+    if (_availableReadConnections.isEmpty &&
+        _allReadConnections.length == maxReaders) {
+      // Wait for available connection
+      return;
+    }
+
+    final nextItem = _queue.removeFirst();
+    nextItem.completer.complete(Future.sync(() async {
+      final nextConnection = _availableReadConnections.isEmpty
+          ? await _expandPool()
+          : _availableReadConnections.removeLast();
       try {
-        return await completer.future;
-      } catch (e) {
-        // throw e;
-        rethrow;
+        final result = await nextConnection.readLock(nextItem.callback);
+        return result;
+      } finally {
+        _availableReadConnections.add(nextConnection);
+        _nextRead();
       }
-    }, debugContext: debugContext ?? 'get*()');
+    }));
+  }
+
+  @override
+  Future<T> readLock<T>(ReadCallback<T> callback,
+      {Duration? lockTimeout, String? debugContext}) async {
+    if (closed) {
+      throw ClosedException();
+    }
+    final zone = _getZone(debugContext: debugContext ?? 'get*()');
+    final item = _PendingItem((ctx) {
+      return zone.runUnary(callback, ctx);
+    });
+    _queue.add(item);
+    _nextRead();
+
+    return await item.completer.future;
   }
 
   @override
@@ -146,41 +147,38 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
   ///    connection (with a different lock).
   /// 2. Give a more specific error message when it happens.
   T _runZoned<T>(T Function() callback, {required String debugContext}) {
+    return _getZone(debugContext: debugContext).run(callback);
+  }
+
+  Zone _getZone({required String debugContext}) {
     if (Zone.current[this] != null) {
       throw LockError(
           'Recursive lock is not allowed. Use `tx.$debugContext` instead of `db.$debugContext`.');
     }
-    var zone = Zone.current.fork(zoneValues: {this: true});
-    return zone.run(callback);
+    return Zone.current.fork(zoneValues: {this: true});
   }
 
-  Future<void> _expandPool() async {
-    if (closed || _readConnections.length >= maxReaders) {
-      return;
-    }
-    bool hasCapacity = _readConnections
-        .any((connection) => !connection.locked && !connection.closed);
-    if (!hasCapacity) {
-      var name = debugName == null
-          ? null
-          : '$debugName-${_readConnections.length + 1}';
-      var connection = SqliteConnectionImpl(
-          upstreamPort: _upstreamPort,
-          primary: false,
-          updates: updates,
-          debugName: name,
-          mutex: mutex,
-          readOnly: true,
-          openFactory: _factory);
-      _readConnections.add(connection);
+  Future<SqliteConnectionImpl> _expandPool() async {
+    var name = debugName == null
+        ? null
+        : '$debugName-${_allReadConnections.length + 1}';
+    var connection = SqliteConnectionImpl(
+        upstreamPort: _upstreamPort,
+        primary: false,
+        updates: updates,
+        debugName: name,
+        mutex: mutex,
+        readOnly: true,
+        openFactory: _factory);
+    _allReadConnections.add(connection);
 
-      // Edge case:
-      // If we don't await here, there is a chance that a different connection
-      // is used for the transaction, and that it finishes and deletes the database
-      // while this one is still opening. This is specifically triggered in tests.
-      // To avoid that, we wait for the connection to be ready.
-      await connection.ready;
-    }
+    // Edge case:
+    // If we don't await here, there is a chance that a different connection
+    // is used for the transaction, and that it finishes and deletes the database
+    // while this one is still opening. This is specifically triggered in tests.
+    // To avoid that, we wait for the connection to be ready.
+    await connection.ready;
+    return connection;
   }
 
   @override
@@ -190,7 +188,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     // It is possible that `readLock()` removes connections from the pool while we're
     // closing connections, but not possible for new connections to be added.
     // Create a copy of the list, to avoid this triggering "Concurrent modification during iteration"
-    final toClose = _readConnections.sublist(0);
+    final toClose = _allReadConnections.toList();
     for (var connection in toClose) {
       // Wait for connection initialization, so that any existing readLock()
       // requests go through before closing.
@@ -202,4 +200,13 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
     // read-only connections first.
     await _writeConnection?.close();
   }
+}
+
+typedef ReadCallback<T> = Future<T> Function(SqliteReadContext tx);
+
+class _PendingItem {
+  ReadCallback<dynamic> callback;
+  Completer<dynamic> completer = Completer.sync();
+
+  _PendingItem(this.callback);
 }

--- a/lib/src/port_channel.dart
+++ b/lib/src/port_channel.dart
@@ -60,7 +60,6 @@ class ParentPortClient implements PortClient {
     });
     _errorPort.listen((message) {
       var [error, stackTrace] = message;
-      print('got an error ${initCompleter.isCompleted} $error');
       if (!initCompleter.isCompleted) {
         if (stackTrace == null) {
           initCompleter.completeError(error);

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -88,6 +88,9 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
   @override
   Future<void> close() async {
     await _connectionMutex.lock(() async {
+      if (closed) {
+        return;
+      }
       if (readOnly) {
         await _isolateClient.post(const _SqliteIsolateConnectionClose());
       } else {
@@ -97,6 +100,7 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
           await _isolateClient.post(const _SqliteIsolateConnectionClose());
         });
       }
+      _isolateClient.close();
       _isolate.kill();
     });
   }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite_async.dart';
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -301,8 +302,11 @@ void main() {
       }).catchError((error) {
         caughtError = error;
       });
-      // This may change into a better error in the future
-      expect(caughtError.toString(), equals("Instance of 'ClosedException'"));
+      // The specific error message may change
+      expect(
+          caughtError.toString(),
+          equals(
+              "IsolateError in sqlite-writer: Invalid argument(s): uncaught async error"));
 
       // Check that we can still continue afterwards
       final computed = await db.computeWithDatabase((db) async {
@@ -328,8 +332,11 @@ void main() {
         }).catchError((error) {
           caughtError = error;
         });
-        // This may change into a better error in the future
-        expect(caughtError.toString(), equals("Instance of 'ClosedException'"));
+        // The specific message may change
+        expect(
+            caughtError.toString(),
+            matches(RegExp(
+                r'IsolateError in sqlite-\d+: Invalid argument\(s\): uncaught async error')));
       }
 
       // Check that we can still continue afterwards

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -383,6 +383,7 @@ void main() {
         // Second connection to sleep more than first connection
         'SELECT test_sleep(test_connection_number() * 10)'
       ]));
+      await db.initialize();
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -377,7 +377,6 @@ void main() {
       // 4. Now second connection is ready. Second query has two connections to choose from.
       // 5. However, first connection is closed, so it's removed from the pool.
       // 6. Triggers `Concurrent modification during iteration: Instance(length:1) of '_GrowableList'`
-
       final db =
           SqliteDatabase.withFactory(testFactory(path: path, initStatements: [
         // Second connection to sleep more than first connection
@@ -387,8 +386,9 @@ void main() {
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');
-      final closeFuture = db.close();
-      await closeFuture;
+
+      await db.close();
+
       await future1;
       await future2;
     });

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,11 +1,9 @@
 import 'dart:async';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite_async.dart';
-import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -383,7 +383,6 @@ void main() {
         // Second connection to sleep more than first connection
         'SELECT test_sleep(test_connection_number() * 10)'
       ]));
-      await createTables(db);
 
       final future1 = db.get('SELECT test_sleep(10) as sleep');
       final future2 = db.get('SELECT test_sleep(10) as sleep');


### PR DESCRIPTION
The old implementation worked as follows:
1. If no idle connection is available and the maxReaders haven't been reached, open another connection.
2. Request a read lock on all open connections.
3. The first available read lock is used. Others are released as soon as the lock was available.

This worked okay for a small number of connections, but scaled quite badly when the number of connections is increased. Even with the default maximum of 5 read connections, the number of read locks/s benchmark is reduced from 107k/s to 36k/s on my machine when those connections have been opened. This adds significant overhead when doing many individual select statements.

This is a complete re-implementation of the logic, using a queue of pending operations and available connections instead. This ends up being simpler (less edge cases), and scales much better with the number of connections.

~Builds on #37~ Now part of this PR:

Fixes #36 (issues when closing the database while queries are still running).

Also improves handling of database initialization errors and other uncaught errors in connection isolates.
