### PR TITLE
Bump version for drift_sqlite_async

### DIFF
--- a/packages/drift_sqlite_async/CHANGELOG.md
+++ b/packages/drift_sqlite_async/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0-alpha.2
+
+- Update dependency `sqlite_async` to version 0.8.0.
 
 ## 0.1.0-alpha.1
 

--- a/packages/drift_sqlite_async/pubspec.yaml
+++ b/packages/drift_sqlite_async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: drift_sqlite_async
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.2
 homepage: https://github.com/powersync-ja/sqlite_async.dart
 repository: https://github.com/powersync-ja/sqlite_async.dart
 description: Use Drift with a sqlite_async database, allowing both to be used in the same application.


### PR DESCRIPTION
## Work done

- Update dependency on `sqlite_async` to version 0.8.0