### PR TITLE
[Fix] `refreshSchema` not working correctly in web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-08-21
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`sqlite_async` - `v0.8.3`](#sqlite_async---v083)
+ - [`drift_sqlite_async` - `v0.1.0-alpha.6`](#drift_sqlite_async---v010-alpha6)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `drift_sqlite_async` - `v0.1.0-alpha.6`
+
+---
+
+#### `sqlite_async` - `v0.8.3`
+
+ - Updated web database implementation for get and getOptional. Fixed refreshSchema not working in web.
+
+
 ## 2024-08-20
 
 ### Changes

--- a/packages/drift_sqlite_async/CHANGELOG.md
+++ b/packages/drift_sqlite_async/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-alpha.6
+
+ - Update a dependency to the latest release.
+
 ## 0.1.0-alpha.5
 
  - Update a dependency to the latest release.

--- a/packages/drift_sqlite_async/pubspec.yaml
+++ b/packages/drift_sqlite_async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: drift_sqlite_async
-version: 0.1.0-alpha.5
+version: 0.1.0-alpha.6
 homepage: https://github.com/powersync-ja/sqlite_async.dart
 repository: https://github.com/powersync-ja/sqlite_async.dart
 description: Use Drift with a sqlite_async database, allowing both to be used in the same application.
@@ -15,7 +15,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
   drift: ">=2.15.0 <2.19.0"
-  sqlite_async: ^0.8.2
+  sqlite_async: ^0.8.3
 dev_dependencies:
   build_runner: ^2.4.8
   drift_dev: ">=2.15.0 <2.19.0"

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.3
+
+ - Updated web database implementation for get and getOptional. Fixed refreshSchema not working in web.
+
 ## 0.8.2
 
 - **FEAT**: Added `refreshSchema()`, allowing queries and watch calls to work against updated schemas.

--- a/packages/sqlite_async/lib/src/sqlite_queries.dart
+++ b/packages/sqlite_async/lib/src/sqlite_queries.dart
@@ -140,6 +140,6 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
 
   @override
   Future<void> refreshSchema() {
-    return get("PRAGMA table_info('sqlite_master')");
+    return getAll("PRAGMA table_info('sqlite_master')");
   }
 }

--- a/packages/sqlite_async/lib/src/web/database.dart
+++ b/packages/sqlite_async/lib/src/web/database.dart
@@ -150,7 +150,7 @@ class _SharedContext implements SqliteReadContext {
   @override
   Future<Row> get(String sql, [List<Object?> parameters = const []]) async {
     final results = await getAll(sql, parameters);
-    return results.single;
+    return results.first;
   }
 
   @override
@@ -169,7 +169,7 @@ class _SharedContext implements SqliteReadContext {
   Future<Row?> getOptional(String sql,
       [List<Object?> parameters = const []]) async {
     final results = await getAll(sql, parameters);
-    return results.singleOrNull;
+    return results.firstOrNull;
   }
 
   void markClosed() {

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.8.2
+version: 0.8.3
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
Found an issue in the powersync tests where the web database throws an error when invoking `refreshSchema`. This was related to web's `get` being implemented slightly different to native. This PR updates get/getOptional to match the native implementation and also changes `refreshSchema` to use `getAll` instead of `get` for good measure.