### PR TITLE
Support latest version of package:web

### DIFF
--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -13,12 +13,12 @@ topics:
 
 dependencies:
   sqlite3: "^2.4.4"
-  sqlite3_web: ^0.1.2-wip
+  sqlite3_web: ^0.1.3
   async: ^2.10.0
   collection: ^1.17.0
   mutex: ^3.1.0
   meta: ^1.10.0
-  web: ^0.5.1
+  web: ^1.0.0
 
 dev_dependencies:
   dcli: ^4.0.0


### PR DESCRIPTION
Supporting the latest version of `package:web` also means that we support the latest version of `package:sqlite3_web` which [contains APIs](https://pub.dev/documentation/sqlite3_web/latest/sqlite3_web/Database/additionalConnection.html) to obtain a web `MessagePort` for an existing database . I will follow up on this with a good way to expose that in this package so that it can be used in the Powersync SDK, but this is already a step to unblock that work.