### PR TITLE
Feat: Expose worker connection

### DIFF
--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.0
+
+- Add the `exposeEndpoint()` method available on web databases. It returns a serializable
+  description of the database endpoint that can be sent across workers.
+  This allows sharing an opened database connection across workers.
+
 ## 0.9.1
 
 - Support version ^0.2.0 of package:sqlite3_web

--- a/packages/sqlite_async/lib/src/web/web_mutex.dart
+++ b/packages/sqlite_async/lib/src/web/web_mutex.dart
@@ -18,7 +18,7 @@ external Navigator get _navigator;
 class MutexImpl implements Mutex {
   late final mutex.Mutex fallback;
   String? identifier;
-  final String _resolvedIdentifier;
+  final String resolvedIdentifier;
 
   MutexImpl({this.identifier})
 
@@ -29,7 +29,7 @@ class MutexImpl implements Mutex {
       ///    - The uuid package could be added for better uniqueness if required.
       ///      This would add another package dependency to `sqlite_async` which is potentially unnecessary at this point.
       /// An identifier should be supplied for better exclusion.
-      : _resolvedIdentifier = identifier ??
+      : resolvedIdentifier = identifier ??
             "${DateTime.now().microsecondsSinceEpoch}-${Random().nextDouble()}" {
     fallback = mutex.Mutex();
   }
@@ -125,7 +125,7 @@ class MutexImpl implements Mutex {
     final lockOptions = JSObject();
     lockOptions['signal'] = controller.signal;
     final promise = _navigator.locks
-        .request(_resolvedIdentifier, lockOptions, jsCallback.toJS);
+        .request(resolvedIdentifier, lockOptions, jsCallback.toJS);
     // A timeout abort will throw an exception which needs to be handled.
     // There should not be any other unhandled lock errors.
     js_util.promiseToFuture(promise).catchError((error) {});

--- a/packages/sqlite_async/lib/web.dart
+++ b/packages/sqlite_async/lib/web.dart
@@ -1,0 +1,68 @@
+/// Exposes interfaces implemented by database implementations on the web.
+///
+/// These expose methods allowing database instances to be shared across web
+/// workers.
+library sqlite_async.web;
+
+import 'package:sqlite3_web/sqlite3_web.dart';
+import 'package:web/web.dart';
+import 'sqlite_async.dart';
+import 'src/web/database.dart';
+
+/// An endpoint that can be used, by any running JavaScript context in the same
+/// website, to connect to an existing [WebSqliteConnection].
+///
+/// These endpoints are created by calling [WebSqliteConnection.exposeEndpoint]
+/// and consist of a [MessagePort] and two [String]s internally identifying the
+/// connection. Both objects can be transferred over send ports towards another
+/// worker or context. That context can then use
+/// [WebSqliteConnection.connectToEndpoint] to connect to the port already
+/// opened.
+typedef WebDatabaseEndpoint = ({
+  MessagePort connectPort,
+  String connectName,
+  String? lockName,
+});
+
+/// A [SqliteConnection] interface implemented by opened connections when
+/// running on the web.
+///
+/// This adds the [exposeEndpoint], which uses `dart:js_interop` types not
+/// supported on native Dart platforms. The method can be used to access an
+/// opened database across different JavaScript contexts
+/// (e.g. document windows and workers).
+abstract class WebSqliteConnection implements SqliteConnection {
+  /// Returns a future that completes when this connection is closed.
+  ///
+  /// This usually only happens when calling [close], but on the web
+  /// specifically, it can also happen when a remote context closes a database
+  /// accessed via [connectToEndpoint].
+  Future<void> get closedFuture;
+
+  /// Returns a [WebDatabaseEndpoint] - a structure that consists only of types
+  /// that can be transferred across a [MessagePort] in JavaScript.
+  ///
+  /// After transferring this endpoint to another JavaScript context (e.g. a
+  /// worker), the worker can call [connectToEndpoint] to obtain a connection to
+  /// the same sqlite database.
+  Future<WebDatabaseEndpoint> exposeEndpoint();
+
+  /// Connect to an endpoint obtained through [exposeEndpoint].
+  ///
+  /// The endpoint is transferrable in JavaScript, allowing multiple JavaScript
+  /// contexts to exchange opened database connections.
+  static Future<WebSqliteConnection> connectToEndpoint(
+      WebDatabaseEndpoint endpoint) async {
+    final rawSqlite = await WebSqlite.connectToPort(
+        (endpoint.connectPort, endpoint.connectName));
+
+    final database = WebDatabase(
+      rawSqlite,
+      switch (endpoint.lockName) {
+        var lock? => Mutex(identifier: lock),
+        null => null,
+      },
+    );
+    return database;
+  }
+}

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.9.1
+version: 0.10.0
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
Continuation of #63 by @simolus3 which adds the `exposeEndpoint()` method on the web.

This PR resolves the conflicts and gets the package ready for release.