### PR TITLE
Update `package:sqlite3`, migrate to new interop APIs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,19 +35,19 @@ jobs:
         include:
           - sqlite_version: "3440200"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3440200.tar.gz"
-            dart_sdk: 3.4.0
+            dart_sdk: 3.5.0
           - sqlite_version: "3430200"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3430200.tar.gz"
-            dart_sdk: 3.4.0
+            dart_sdk: 3.5.0
           - sqlite_version: "3420000"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
-            dart_sdk: 3.4.0
+            dart_sdk: 3.5.0
           - sqlite_version: "3410100"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz"
-            dart_sdk: 3.4.0
+            dart_sdk: 3.5.0
           - sqlite_version: "3380000"
             sqlite_url: "https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz"
-            dart_sdk: 3.4.0
+            dart_sdk: 3.5.0
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.1
+
+- Remove remaining `dart:js_util` imports in favor of new interop APIs.
+- Add `WebSqliteOpenFactory` with web-specific behavior for open factories.
+
 ## 0.11.0
 
  - Automatically flush IndexedDB storage to fix durability issues

--- a/packages/sqlite_async/lib/src/impl/isolate_connection_factory_impl.dart
+++ b/packages/sqlite_async/lib/src/impl/isolate_connection_factory_impl.dart
@@ -2,4 +2,4 @@ export 'stub_isolate_connection_factory.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '../native/native_isolate_connection_factory.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.html) '../web/web_isolate_connection_factory.dart';
+    if (dart.library.js_interop) '../web/web_isolate_connection_factory.dart';

--- a/packages/sqlite_async/lib/src/impl/mutex_impl.dart
+++ b/packages/sqlite_async/lib/src/impl/mutex_impl.dart
@@ -2,4 +2,4 @@ export 'stub_mutex.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '../native/native_isolate_mutex.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.html) '../web/web_mutex.dart';
+    if (dart.library.js_interop) '../web/web_mutex.dart';

--- a/packages/sqlite_async/lib/src/impl/open_factory_impl.dart
+++ b/packages/sqlite_async/lib/src/impl/open_factory_impl.dart
@@ -2,4 +2,4 @@ export 'stub_sqlite_open_factory.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '../native/native_sqlite_open_factory.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.html) '../web/web_sqlite_open_factory.dart';
+    if (dart.library.js_interop) '../web/web_sqlite_open_factory.dart';

--- a/packages/sqlite_async/lib/src/impl/sqlite_database_impl.dart
+++ b/packages/sqlite_async/lib/src/impl/sqlite_database_impl.dart
@@ -2,4 +2,4 @@ export 'stub_sqlite_database.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '../native/database/native_sqlite_database.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.html) '../web/database/web_sqlite_database.dart';
+    if (dart.library.js_interop) '../web/database/web_sqlite_database.dart';

--- a/packages/sqlite_async/lib/src/web/web_mutex.dart
+++ b/packages/sqlite_async/lib/src/web/web_mutex.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart' as mutex;
 import 'dart:js_interop';
-import 'dart:js_util' as js_util;
 // This allows for checking things like hasProperty without the need for depending on the `js` package
 import 'dart:js_interop_unsafe';
 import 'package:web/web.dart';
@@ -128,7 +127,7 @@ class MutexImpl implements Mutex {
         .request(resolvedIdentifier, lockOptions, jsCallback.toJS);
     // A timeout abort will throw an exception which needs to be handled.
     // There should not be any other unhandled lock errors.
-    js_util.promiseToFuture(promise).catchError((error) {});
+    promise.toDart.catchError((error) => null);
     return gotLock.future;
   }
 

--- a/packages/sqlite_async/lib/src/web/worker/throttled_common_database.dart
+++ b/packages/sqlite_async/lib/src/web/worker/throttled_common_database.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:sqlite_async/sqlite3_common.dart';
+import 'package:sqlite_async/sqlite3_wasm.dart';
 
 /// Wrap a CommonDatabase to throttle its updates stream.
 /// This is so that we can throttle the updates _within_
@@ -103,6 +103,17 @@ class ThrottledCommonDatabase extends CommonDatabase {
   Stream<SqliteUpdate> get updates {
     return throttledUpdates(_db, _transactionController.stream);
   }
+
+  @override
+  VoidPredicate? get commitFilter => _db.commitFilter;
+
+  set commitFilter(VoidPredicate? filter) => _db.commitFilter = filter;
+
+  @override
+  Stream<void> get commits => _db.commits;
+
+  @override
+  Stream<void> get rollbacks => _db.rollbacks;
 }
 
 /// This throttles the database update stream to:

--- a/packages/sqlite_async/lib/src/web/worker/worker_utils.dart
+++ b/packages/sqlite_async/lib/src/web/worker/worker_utils.dart
@@ -1,5 +1,4 @@
 import 'dart:js_interop';
-import 'dart:js_util' as js_util;
 
 import 'package:mutex/mutex.dart';
 import 'package:sqlite3/wasm.dart';
@@ -73,7 +72,7 @@ class AsyncSqliteDatabase extends WorkerDatabase {
 
         var dartMap = resultSetToMap(res);
 
-        var jsObject = js_util.jsify(dartMap);
+        var jsObject = dartMap.jsify();
 
         return jsObject;
       case CustomDatabaseMessageKind.executeBatchInTransaction:

--- a/packages/sqlite_async/lib/web.dart
+++ b/packages/sqlite_async/lib/web.dart
@@ -6,6 +6,8 @@ library sqlite_async.web;
 
 import 'package:sqlite3_web/sqlite3_web.dart';
 import 'package:web/web.dart';
+
+import 'sqlite3_common.dart';
 import 'sqlite_async.dart';
 import 'src/web/database.dart';
 
@@ -23,6 +25,22 @@ typedef WebDatabaseEndpoint = ({
   String connectName,
   String? lockName,
 });
+
+/// An additional interface for [SqliteOpenFactory] exposing additional
+/// functionality that is only relevant when compiling to the web.
+///
+/// The [DefaultSqliteOpenFactory] class implements this interface only when
+/// compiling for the web.
+abstract interface class WebSqliteOpenFactory
+    implements SqliteOpenFactory<CommonDatabase> {
+  /// Opens a [WebSqlite] instance for the given [options].
+  ///
+  /// This method can be overriden in scenarios where the way [WebSqlite] is
+  /// opened needs to be customized. Implementers should be aware that the
+  /// result of this method is cached and will be re-used by the open factory
+  /// when provided with the same [options] again.
+  Future<WebSqlite> openWebSqlite(WebSqliteOptions options);
+}
 
 /// A [SqliteConnection] interface implemented by opened connections when
 /// running on the web.

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -3,7 +3,7 @@ description: High-performance asynchronous interface for SQLite on Dart and Flut
 version: 0.11.1
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
 
 topics:
   - sqlite

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - flutter
 
 dependencies:
-  sqlite3: ^2.6.0
+  sqlite3: ^2.7.0
   sqlite3_web: ^0.2.1
   async: ^2.10.0
   collection: ^1.17.0

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.11.0
+version: 0.11.1
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -12,8 +12,8 @@ topics:
   - flutter
 
 dependencies:
-  sqlite3: "^2.4.7"
-  sqlite3_web: ^0.2.0
+  sqlite3: ^2.6.0
+  sqlite3_web: ^0.2.1
   async: ^2.10.0
   collection: ^1.17.0
   mutex: ^3.1.0

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -12,8 +12,8 @@ topics:
   - flutter
 
 dependencies:
-  sqlite3: ^2.7.0
-  sqlite3_web: ^0.2.1
+  sqlite3: ^2.7.2
+  sqlite3_web: ^0.2.2
   async: ^2.10.0
   collection: ^1.17.0
   mutex: ^3.1.0

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
 
 dev_dependencies:
   dcli: ^4.0.0
-  js: ^0.6.7
   lints: ^3.0.0
   test: ^1.21.0
   test_api: ^0.7.0

--- a/packages/sqlite_async/test/utils/test_utils_impl.dart
+++ b/packages/sqlite_async/test/utils/test_utils_impl.dart
@@ -2,4 +2,4 @@ export 'stub_test_utils.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) 'native_test_utils.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.html) 'web_test_utils.dart';
+    if (dart.library.js_interop) 'web_test_utils.dart';

--- a/packages/sqlite_async/test/utils/web_test_utils.dart
+++ b/packages/sqlite_async/test/utils/web_test_utils.dart
@@ -19,7 +19,7 @@ class TestUtils extends AbstractTestUtils {
 
   Future<void> _init() async {
     final channel = spawnHybridUri('/test/server/worker_server.dart');
-    final port = (await channel.stream.first as num).toInt();
+    final port = await channel.stream.first as int;
     final sqliteWasmUri = 'http://localhost:$port/sqlite3.wasm';
     // Cross origin workers are not supported, but we can supply a Blob
     var sqliteUri = 'http://localhost:$port/db_worker.js';

--- a/packages/sqlite_async/test/utils/web_test_utils.dart
+++ b/packages/sqlite_async/test/utils/web_test_utils.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:html';
+import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart' show Blob, BlobPart, BlobPropertyBag;
 import 'abstract_test_utils.dart';
 
 @JS('URL.createObjectURL')
@@ -19,13 +19,13 @@ class TestUtils extends AbstractTestUtils {
 
   Future<void> _init() async {
     final channel = spawnHybridUri('/test/server/worker_server.dart');
-    final port = await channel.stream.first as int;
+    final port = (await channel.stream.first as num).toInt();
     final sqliteWasmUri = 'http://localhost:$port/sqlite3.wasm';
     // Cross origin workers are not supported, but we can supply a Blob
     var sqliteUri = 'http://localhost:$port/db_worker.js';
 
-    final blob = Blob(
-        <String>['importScripts("$sqliteUri");'], 'application/javascript');
+    final blob = Blob(<BlobPart>['importScripts("$sqliteUri");'.toJS].toJS,
+        BlobPropertyBag(type: 'application/javascript'));
     sqliteUri = _createObjectURL(blob);
 
     webOptions = SqliteOptions(


### PR DESCRIPTION
Update `package:sqlite3` and `package:sqlite3_web`. This changes:

- The `sqlite3` package now provides commit and rollback notifications. That causes compilation errors in our `ThrottledDatabase` wrapper. That's not a huge problem because that class is only imported in workers (which we provide for users) and existing compiled workers are compatible with the updated `sqlite3` package. This PR adds the missing methods.
- Also, `sqlite3_web` added support for accessing databases in the same context (so without a worker). To support this in `sqlite3_async` (and later the PowerSync SDK as well), the `AsyncSqliteController` now needs to be injected when opening `WebSqlite` (previously, the controller was only part of the worker).
  - I've also added a public interface which allows `package:powersync_core` to inject its own controller (since the same thing applies - previously this was only part of the db worker, now we might also need it in the main context).
- Finally, I've also replaced the legacy web-interop libraries from the SDK with the newer ones.