### PR TITLE
Allow wrapping raw synchronous databases as `SqliteDatabase`

### DIFF
--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.11.4
+
+- Add `SqliteConnection.synchronousWrapper` and `SqliteDatabase.singleConnection`.
+  Together, these can be used to wrap raw `CommonDatabase` instances from `package:sqlite3`
+  as a `Database` (without an automated worker or isolate setup). This can be useful in tests
+  where synchronous access to the underlying database is convenient.
+
 ## 0.11.3
 
 - Support being compiled with `package:build_web_compilers`.

--- a/packages/sqlite_async/lib/src/common/sqlite_database.dart
+++ b/packages/sqlite_async/lib/src/common/sqlite_database.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:sqlite_async/src/common/abstract_open_factory.dart';
 import 'package:sqlite_async/src/common/isolate_connection_factory.dart';
+import 'package:sqlite_async/src/impl/single_connection_database.dart';
 import 'package:sqlite_async/src/impl/sqlite_database_impl.dart';
 import 'package:sqlite_async/src/sqlite_options.dart';
 import 'package:sqlite_async/src/sqlite_queries.dart';
@@ -81,5 +82,25 @@ abstract class SqliteDatabase
       AbstractDefaultSqliteOpenFactory openFactory,
       {int maxReaders = SqliteDatabase.defaultMaxReaders}) {
     return SqliteDatabaseImpl.withFactory(openFactory, maxReaders: maxReaders);
+  }
+
+  /// Opens a [SqliteDatabase] that only wraps an underlying connection.
+  ///
+  /// This function may be useful in some instances like tests, but should not
+  /// typically be used by applications. Compared to the other ways to open
+  /// databases, it has the following downsides:
+  ///
+  ///  1. No connection pool / concurrent readers for native databases.
+  ///  2. No reliable update notifications on the web.
+  ///  3. There is no reliable transaction management in Dart, and opening the
+  ///     same database with [SqliteDatabase.singleConnection] multiple times
+  ///     may cause "database is locked" errors.
+  ///
+  /// Together with [SqliteConnection.synchronousWrapper], this can be used to
+  /// open in-memory databases (e.g. via [SqliteOpenFactory.open]). That
+  /// bypasses most convenience features, but may still be useful for
+  /// short-lived databases used in tests.
+  factory SqliteDatabase.singleConnection(SqliteConnection connection) {
+    return SingleConnectionDatabase(connection);
   }
 }

--- a/packages/sqlite_async/lib/src/impl/single_connection_database.dart
+++ b/packages/sqlite_async/lib/src/impl/single_connection_database.dart
@@ -1,0 +1,60 @@
+import 'package:sqlite3/common.dart';
+import 'package:sqlite_async/sqlite_async.dart';
+
+/// A database implementation that delegates everything to a single connection.
+///
+/// This doesn't provide an automatic connection pool or the web worker
+/// management, but it can still be useful in cases like unit tests where those
+/// features might not be necessary. Since only a single sqlite connection is
+/// used internally, this also allows using in-memory databases.
+final class SingleConnectionDatabase
+    with SqliteQueries, SqliteDatabaseMixin
+    implements SqliteDatabase {
+  final SqliteConnection connection;
+
+  SingleConnectionDatabase(this.connection);
+
+  @override
+  Future<void> close() => connection.close();
+
+  @override
+  bool get closed => connection.closed;
+
+  @override
+  Future<bool> getAutoCommit() => connection.getAutoCommit();
+
+  @override
+  Future<void> get isInitialized => Future.value();
+
+  @override
+  IsolateConnectionFactory<CommonDatabase> isolateConnectionFactory() {
+    throw UnsupportedError(
+        "SqliteDatabase.singleConnection instances can't be used across "
+        'isolates.');
+  }
+
+  @override
+  int get maxReaders => 1;
+
+  @override
+  AbstractDefaultSqliteOpenFactory<CommonDatabase> get openFactory =>
+      throw UnimplementedError();
+
+  @override
+  Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
+      {Duration? lockTimeout, String? debugContext}) {
+    return connection.readLock(callback,
+        lockTimeout: lockTimeout, debugContext: debugContext);
+  }
+
+  @override
+  Stream<UpdateNotification> get updates =>
+      connection.updates ?? const Stream.empty();
+
+  @override
+  Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
+      {Duration? lockTimeout, String? debugContext}) {
+    return connection.writeLock(callback,
+        lockTimeout: lockTimeout, debugContext: debugContext);
+  }
+}

--- a/packages/sqlite_async/lib/src/sqlite_connection.dart
+++ b/packages/sqlite_async/lib/src/sqlite_connection.dart
@@ -1,7 +1,11 @@
 import 'dart:async';
 
 import 'package:sqlite3/common.dart' as sqlite;
+import 'package:sqlite_async/mutex.dart';
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/src/update_notification.dart';
+
+import 'common/connection/sync_sqlite_connection.dart';
 
 /// Abstract class representing calls available in a read-only or read-write context.
 abstract class SqliteReadContext {
@@ -74,7 +78,26 @@ abstract class SqliteWriteContext extends SqliteReadContext {
 }
 
 /// Abstract class representing a connection to the SQLite database.
+///
+/// This package typically pools multiple [SqliteConnection] instances into a
+/// managed [SqliteDatabase] automatically.
 abstract class SqliteConnection extends SqliteWriteContext {
+  /// Default constructor for subclasses.
+  SqliteConnection();
+
+  /// Creates a [SqliteConnection] instance that wraps a raw [CommonDatabase]
+  /// from the `sqlite3` package.
+  ///
+  /// Users should not typically create connections manually at all. Instead,
+  /// open a [SqliteDatabase] through a factory. In special scenarios where it
+  /// may be easier to wrap a [raw] databases (like unit tests), this method
+  /// may be used as an escape hatch for the asynchronous wrappers provided by
+  /// this package.
+  factory SqliteConnection.synchronousWrapper(CommonDatabase raw,
+      {Mutex? mutex}) {
+    return SyncSqliteConnection(raw, mutex ?? Mutex());
+  }
+
   /// Reports table change update notifications
   Stream<UpdateNotification>? get updates;
 

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.11.3
+version: 0.11.4
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.5.0 <4.0.0"

--- a/packages/sqlite_async/test/utils/abstract_test_utils.dart
+++ b/packages/sqlite_async/test/utils/abstract_test_utils.dart
@@ -1,3 +1,4 @@
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
 class TestDefaultSqliteOpenFactory extends DefaultSqliteOpenFactory {
@@ -5,6 +6,10 @@ class TestDefaultSqliteOpenFactory extends DefaultSqliteOpenFactory {
 
   TestDefaultSqliteOpenFactory(
       {required super.path, super.sqliteOptions, this.sqlitePath = ''});
+
+  Future<CommonDatabase> openDatabaseForSingleConnection() async {
+    return openDB(SqliteOpenOptions(primaryConnection: true, readOnly: false));
+  }
 }
 
 abstract class AbstractTestUtils {


### PR DESCRIPTION
The asynchronous, isolate-based APIs provided by this package are a great default to access sqlite databases. For some test setups, they can stand in the way however. In particular,

1. They make it almost impossible to use in-memory databases (which are otherwise a great fit for tests).
2. The use of multiple isolates makes some async interactions much harder to debug (I ran into this writing tests for the PowerSync SDK, which was frustrating enough to make these changes here 😄 ).
3. Since the default factories set up workers, it's impossible to register custom functions in tests without compiling a custom worker for tests.

While it's a good thing that our unit tests have a setup very similar to what users have in practice, some individual components are easier to test when keeping everything on a single isolate. So, this:

1. Exports the existing `SyncSqliteConnection` as an easily-accessible factory wrapping a `CommonDatabase`.
2. Allows turning a single `SqliteConnection` into a `SqliteDatabase`.

There are documentation comments warning that these methods should not be used in apps, but they are helpful for tests.