### PR TITLE
Fix web database not respecting lock timeouts

### DIFF
--- a/packages/sqlite_async/lib/src/web/database.dart
+++ b/packages/sqlite_async/lib/src/web/database.dart
@@ -86,7 +86,7 @@ class WebDatabase
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
       {Duration? lockTimeout, String? debugContext}) async {
     if (_mutex case var mutex?) {
-      return await mutex.lock(() async {
+      return await mutex.lock(timeout: lockTimeout, () async {
         final context = _SharedContext(this);
         try {
           return await callback(context);
@@ -135,7 +135,7 @@ class WebDatabase
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext, bool? flush}) async {
     if (_mutex case var mutex?) {
-      return await mutex.lock(() async {
+      return await mutex.lock(timeout: lockTimeout, () async {
         final context = _ExclusiveContext(this);
         try {
           return await callback(context);

--- a/packages/sqlite_async/lib/src/web/web_mutex.dart
+++ b/packages/sqlite_async/lib/src/web/web_mutex.dart
@@ -16,10 +16,9 @@ external Navigator get _navigator;
 /// Web implementation of [Mutex]
 class MutexImpl implements Mutex {
   late final mutex.Mutex fallback;
-  String? identifier;
   final String resolvedIdentifier;
 
-  MutexImpl({this.identifier})
+  MutexImpl({String? identifier})
 
       /// On web a lock name is required for Navigator locks.
       /// Having exclusive Mutex instances requires a somewhat unique lock name.
@@ -40,7 +39,7 @@ class MutexImpl implements Mutex {
 
   @override
   Future<T> lock<T>(Future<T> Function() callback, {Duration? timeout}) {
-    if ((_navigator as JSObject).hasProperty('locks'.toJS).toDart) {
+    if (_navigator.has('locks')) {
       return _webLock(callback, timeout: timeout);
     } else {
       return _fallbackLock(callback, timeout: timeout);


### PR DESCRIPTION
The `readLock` and `writeLock` APIs have a `lockTimeout` parameter to not wait on locks longer than intended. The `WebDatabase` implementation did not forward these arguments properly, this fixes that.

I've also removed an unused field on `MutexImpl` on the web and simplified the check for `navigator.locks` a bit.