### PR TITLE
Fix write detection when using UPDATE/INSERT/DELETE with RETURNING in raw queries

### DIFF
--- a/packages/drift_sqlite_async/CHANGELOG.md
+++ b/packages/drift_sqlite_async/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Fix write detection when using UPDATE/INSERT/DELETE with RETURNING in raw queries.
+
 ## 0.2.1
 
 - Fix lints.

--- a/packages/drift_sqlite_async/lib/src/executor.dart
+++ b/packages/drift_sqlite_async/lib/src/executor.dart
@@ -8,7 +8,8 @@ import 'package:sqlite_async/sqlite_async.dart';
 // Ends with " RETURNING *", or starts with insert/update/delete.
 // Drift-generated queries will always have the RETURNING *.
 // The INSERT/UPDATE/DELETE check is for custom queries, and is not exhaustive.
-final _returningCheck = RegExp(r'( RETURNING \*;?$)|(^(INSERT|UPDATE|DELETE))',
+final _returningCheck = RegExp(
+    r'( RETURNING \*;?\s*$)|(^\s*(INSERT|UPDATE|DELETE))',
     caseSensitive: false);
 
 class _SqliteAsyncDelegate extends _SqliteAsyncQueryDelegate

--- a/packages/drift_sqlite_async/pubspec.yaml
+++ b/packages/drift_sqlite_async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: drift_sqlite_async
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/powersync-ja/sqlite_async.dart
 repository: https://github.com/powersync-ja/sqlite_async.dart
 description: Use Drift with a sqlite_async database, allowing both to be used in the same application.


### PR DESCRIPTION
Hello,

We've noticed some errors in our Sentry logs where sometimes we were getting database is locked during a COMMIT. After some investigation we found out that it was caused by a raw update with returning statement we were using in our app that had leading spaces. This made the regexp consider them as read, which can cause simultaneous writes when using the pool implementation in SQLite Async with multiple readers.

My proposal fix is updating the regex, but an alternative fix would be to trim the incoming statement. 