### PR TITLE
Add test ensuring delete returns affected rows

### DIFF
--- a/packages/drift_sqlite_async/test/db_test.dart
+++ b/packages/drift_sqlite_async/test/db_test.dart
@@ -107,7 +107,7 @@ void main() {
           ]));
     });
 
-    test('delete', () async {
+    test('delete returns affected rows', () async {
       for (var i = 0; i < 10; i++) {
         await dbu
             .into(dbu.todoItems)

--- a/packages/drift_sqlite_async/test/db_test.dart
+++ b/packages/drift_sqlite_async/test/db_test.dart
@@ -106,5 +106,16 @@ void main() {
             '[]'
           ]));
     });
+
+    test('delete', () async {
+      for (var i = 0; i < 10; i++) {
+        await dbu
+            .into(dbu.todoItems)
+            .insert(TodoItemsCompanion.insert(description: 'desc $i'));
+      }
+
+      final deleted = await dbu.delete(dbu.todoItems).go();
+      expect(deleted, 10);
+    });
   });
 }


### PR DESCRIPTION
A customer reported `delete` in drift not returning the amount of affected rows. Since it doesn't look like this case was tested before, I've added a small test for that case now.

It does look like everything is working correctly though.