### PR TITLE
Make watch queries easier to cancel

### DIFF
--- a/packages/sqlite_async/lib/src/update_notification.dart
+++ b/packages/sqlite_async/lib/src/update_notification.dart
@@ -52,10 +52,13 @@ class UpdateNotification {
   static Stream<UpdateNotification> throttleStream(
       Stream<UpdateNotification> input, Duration timeout,
       {UpdateNotification? addOne}) {
-    return _throttleStream(input, timeout, addOne: addOne, throttleFirst: true,
-        add: (a, b) {
-      return a.union(b);
-    });
+    return _throttleStream(
+      input: input,
+      timeout: timeout,
+      throttleFirst: true,
+      add: (a, b) => a.union(b),
+      addOne: addOne,
+    );
   }
 
   /// Filter an update stream by specific tables.
@@ -67,62 +70,112 @@ class UpdateNotification {
   }
 }
 
-/// Given a broadcast stream, return a singular throttled stream that is throttled.
-/// This immediately starts listening.
+/// Throttles an [input] stream to not emit events more often than with a
+/// frequency of 1/[timeout].
 ///
-/// Behaviour:
-///   If there was no event in "timeout", and one comes in, it is pushed immediately.
-///   Otherwise, we wait until the timeout is over.
-Stream<T> _throttleStream<T extends Object>(Stream<T> input, Duration timeout,
-    {bool throttleFirst = false, T Function(T, T)? add, T? addOne}) async* {
-  var nextPing = Completer<void>();
-  var done = false;
-  T? lastData;
+/// When an event is received and no timeout window is active, it is forwarded
+/// downstream and a timeout window is started. For events received within a
+/// timeout window, [add] is called to fold events. Then when the window
+/// expires, pending events are emitted.
+/// The subscription to the [input] stream is never paused.
+///
+/// When the returned stream is paused, an active timeout window is reset and
+/// restarts after the stream is resumed.
+///
+/// If [addOne] is not null, that event will always be added when the stream is
+/// subscribed to.
+/// When [throttleFirst] is true, a timeout window begins immediately after
+/// listening (so that the first event, apart from [addOne], is emitted no
+/// earlier than after [timeout]).
+Stream<T> _throttleStream<T extends Object>({
+  required Stream<T> input,
+  required Duration timeout,
+  required bool throttleFirst,
+  required T Function(T, T) add,
+  required T? addOne,
+}) {
+  return Stream.multi((listener) {
+    T? pendingData;
+    Timer? activeTimeoutWindow;
 
-  var listener = input.listen((data) {
-    if (lastData != null && add != null) {
-      lastData = add(lastData!, data);
-    } else {
-      lastData = data;
-    }
-    if (!nextPing.isCompleted) {
-      nextPing.complete();
-    }
-  }, onDone: () {
-    if (!nextPing.isCompleted) {
-      nextPing.complete();
+    /// Add pending data, bypassing the active timeout window.
+    ///
+    /// This is used to forward error and done events immediately.
+    bool addPendingEvents() {
+      if (pendingData case final data?) {
+        pendingData = null;
+        listener.addSync(data);
+        activeTimeoutWindow?.cancel();
+        return true;
+      } else {
+        return false;
+      }
     }
 
-    done = true;
-  });
+    /// Emits [pendingData] if no timeout window is active, and then starts a
+    /// timeout window if necessary.
+    void maybeEmit() {
+      if (activeTimeoutWindow == null && !listener.isPaused) {
+        final didAdd = addPendingEvents();
+        if (didAdd) {
+          activeTimeoutWindow = Timer(timeout, () {
+            activeTimeoutWindow = null;
+            maybeEmit();
+          });
+        }
+      }
+    }
 
-  try {
+    void setTimeout() {
+      activeTimeoutWindow = Timer(timeout, () {
+        activeTimeoutWindow = null;
+        maybeEmit();
+      });
+    }
+
+    void onData(T data) {
+      pendingData = switch (pendingData) {
+        null => data,
+        final pending => add(pending, data),
+      };
+      maybeEmit();
+    }
+
+    void onError(Object error, StackTrace trace) {
+      addPendingEvents();
+      listener.addErrorSync(error, trace);
+    }
+
+    void onDone() {
+      addPendingEvents();
+      listener.closeSync();
+    }
+
+    final subscription = input.listen(onData, onError: onError, onDone: onDone);
+    var needsTimeoutWindowAfterResume = false;
+
+    listener.onPause = () {
+      needsTimeoutWindowAfterResume = activeTimeoutWindow != null;
+      activeTimeoutWindow?.cancel();
+    };
+    listener.onResume = () {
+      if (needsTimeoutWindowAfterResume) {
+        setTimeout();
+      } else {
+        maybeEmit();
+      }
+    };
+    listener.onCancel = () async {
+      activeTimeoutWindow?.cancel();
+      return subscription.cancel();
+    };
+
     if (addOne != null) {
-      yield addOne;
+      // This must not be sync, we're doing this directly in onListen
+      listener.add(addOne);
     }
     if (throttleFirst) {
-      await Future.delayed(timeout);
+      setTimeout();
     }
-    while (!done) {
-      // If a value is available now, we'll use it immediately.
-      // If not, this waits for it.
-      await nextPing.future;
-      if (done) break;
-
-      // Capture any new values coming in while we wait.
-      nextPing = Completer<void>();
-      T data = lastData as T;
-      // Clear before we yield, so that we capture new changes while yielding
-      lastData = null;
-      yield data;
-      // Wait a minimum of this duration between tasks
-      await Future.delayed(timeout);
-    }
-  } finally {
-    if (lastData case final data?) {
-      yield data;
-    }
-
-    await listener.cancel();
-  }
+  });
 }

--- a/packages/sqlite_async/test/watch_test.dart
+++ b/packages/sqlite_async/test/watch_test.dart
@@ -113,8 +113,10 @@ void main() {
           lastCount = count;
         }
 
-        // The number of read queries must not be greater than the number of writes overall.
-        expect(numberOfQueries, lessThanOrEqualTo(results.last.first['count']));
+        // The number of read queries must not be greater than the number of
+        // writes overall, plus one for the initial stream emission.
+        expect(numberOfQueries,
+            lessThanOrEqualTo(results.last.first['count'] + 1));
 
         DateTime? lastTime;
         for (var r in times) {
@@ -283,7 +285,7 @@ void main() {
       });
       await Future.delayed(delay);
 
-      subscription.cancel();
+      await subscription.cancel();
 
       expect(
           counts,


### PR DESCRIPTION
This refactors our `watch` query stream implementation slightly:

1. Addressing the `FIXME` comment in `watch()`, this refactors the stream implementation there to use stream combinators instead of `async*`. As that comment explains, cancelling the stream might run the query another time which is not typically what users want.
2. The `_throttleStream` implementation, also using `async*`, had a similar issue where it couldn't be cancelled efficiently when it's in the `await Future.delayed(timeout);` stage. I've rewritten that method with a manual stream subscription to be more explicit about how we deal with downstream listeners pausing / cancelling the stream (personally, I find the exact semantics of `async*` quite hard to understand).