### PR TITLE
Fix unrecoverable error when opening native db

### DIFF
--- a/packages/sqlite_async/lib/src/common/port_channel_native.dart
+++ b/packages/sqlite_async/lib/src/common/port_channel_native.dart
@@ -30,12 +30,10 @@ class ParentPortClient implements PortClient {
   ParentPortClient() {
     final initCompleter = Completer<SendPort>.sync();
     sendPortFuture = initCompleter.future;
-    sendPortFuture.then((value) {
-      sendPort = value;
-    });
     _receivePort.listen((message) {
       if (message is _InitMessage) {
         assert(!initCompleter.isCompleted);
+        sendPort = message.port;
         initCompleter.complete(message.port);
       } else if (message is _PortChannelResult) {
         final handler = handlers.remove(message.requestId);

--- a/packages/sqlite_async/lib/src/native/database/native_sqlite_database.dart
+++ b/packages/sqlite_async/lib/src/native/database/native_sqlite_database.dart
@@ -34,8 +34,8 @@ class SqliteDatabaseImpl
 
   @override
   @protected
-  // Native doesn't require any asynchronous initialization
-  late Future<void> isInitialized = Future.value();
+  // ignore: invalid_use_of_protected_member
+  late Future<void> isInitialized = _internalConnection.isInitialized;
 
   late final SqliteConnectionImpl _internalConnection;
   late final SqliteConnectionPool _pool;


### PR DESCRIPTION
When opening a native database fails (for instance because the open factory is misconfigured and sends an invalid statement as a open pragma), we don't properly report this error to the client.

I would expect it to be reported through the `initialize()` future, but that actually misses the error. Also, the error is always reported as an unhandled exception which can easily crash the app.

This fixes these issues by:

1. Making `SqliteDatabaseImpl.initialized` report `SqliteConnectionImpl.initialized` instead of an always-completed future.
2. Avoid sending a close message if the isolate has crashed during open - we'll just get a guaranteed "already closed" error.
3. In `SqliteoConnectionImpl`, make `isInitialized` point to `_open`. Previously, `_open` was unawaited which caused an unhandled exception if an exception was thrown there.
4. In `ParentPortClient`, don't use `sendPortFuture.then()`. Attaching a first listener without an error handler used to also cause unhandled exceptions for reasons I'm not sure I understand. As an alternative we can set the `SendPort` field in the only place where `initCompleter.complete` is called.