### PR TITLE
Prepare 0.11.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-05-28
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`sqlite_async` - `v0.11.6`](#sqlite_async---v0116)
+
+---
+
+#### `sqlite_async` - `v0.11.6`
+
+- Native: Consistently report errors when opening the database instead of
+  causing unhandled exceptions.
+
 ## 2025-05-22
 
 ---

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.6
+
+- Native: Consistently report errors when opening the database instead of
+  causing unhandled exceptions.
+
 ## 0.11.5
 
 - Allow profiling queries. Queries are profiled by default in debug and profile builds, the runtime

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.11.5
+version: 0.11.6
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
This prepares a release for `sqlite_async` version `0.11.6`, I can push the release after an approval.

Only change: https://github.com/powersync-ja/sqlite_async.dart/pull/95