### PR TITLE
Fix a race condition around OPFS databases

### DIFF
--- a/packages/sqlite_async/lib/src/web/database/web_sqlite_database.dart
+++ b/packages/sqlite_async/lib/src/web/database/web_sqlite_database.dart
@@ -8,7 +8,6 @@ import 'package:sqlite_async/src/common/sqlite_database.dart';
 import 'package:sqlite_async/src/sqlite_connection.dart';
 import 'package:sqlite_async/src/sqlite_options.dart';
 import 'package:sqlite_async/src/update_notification.dart';
-import 'package:sqlite_async/src/web/web_mutex.dart';
 import 'package:sqlite_async/src/web/web_sqlite_open_factory.dart';
 import 'package:sqlite_async/web.dart';
 
@@ -43,7 +42,6 @@ class SqliteDatabaseImpl
   @override
   AbstractDefaultSqliteOpenFactory openFactory;
 
-  late final Mutex mutex;
   late final WebDatabase _connection;
   StreamSubscription? _broadcastUpdatesSubscription;
 
@@ -77,15 +75,15 @@ class SqliteDatabaseImpl
   ///  4. Creating temporary views or triggers.
   SqliteDatabaseImpl.withFactory(this.openFactory,
       {this.maxReaders = SqliteDatabase.defaultMaxReaders}) {
-    mutex = MutexImpl();
     // This way the `updates` member is available synchronously
     updates = updatesController.stream;
     isInitialized = _init();
   }
 
   Future<void> _init() async {
-    _connection = await openFactory.openConnection(SqliteOpenOptions(
-        primaryConnection: true, readOnly: false, mutex: mutex)) as WebDatabase;
+    _connection = await openFactory.openConnection(
+            SqliteOpenOptions(primaryConnection: true, readOnly: false))
+        as WebDatabase;
 
     final broadcastUpdates = _connection.broadcastUpdates;
     if (broadcastUpdates == null) {


### PR DESCRIPTION
In `web_sqlite_open_factory.dart`, we create a shared mutex derived from the database path when a database is not accessed through shared workers. This is relevant when serving Flutter apps with COOP + COEP headers, because we're able to use a VFS implementation based on OPFS and dedicated workers in that case (so no shared worker is involved).

Unfortunately, `web_sqlite_database.dart` allocates its own (anonymous) mutex and passes that as an option to the open factory. This means that the shared mutex isn't used, and two tabs could race to use the database simultaneously, which may cause errors as the VFS runs into blocked sync access handles.

Note: A side-effect of this change is that databases with shared workers have no per-tab/client-side lock. This shouldn't be an issue because the shared worker is supposed to hand out leases as well, but it's something to be aware of. I'm not sure if we should restore the old behavior for shared workers, I need to test this more.