### PR TITLE
Shared worker: Release mutex when tab closes

### DIFF
--- a/packages/sqlite_async/build.yaml
+++ b/packages/sqlite_async/build.yaml
@@ -1,0 +1,9 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers:entrypoint:
+        options:
+          # Workers can't be compiled with dartdevc, so use dart2js for the example
+          compiler: dart2js
+        generate_for:
+          - example/web/**

--- a/packages/sqlite_async/build.yaml
+++ b/packages/sqlite_async/build.yaml
@@ -5,5 +5,3 @@ targets:
         options:
           # Workers can't be compiled with dartdevc, so use dart2js for the example
           compiler: dart2js
-        generate_for:
-          - example/web/**

--- a/packages/sqlite_async/example/web/index.html
+++ b/packages/sqlite_async/example/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>sqlite_async web demo</title>
+    <script defer src="main.dart.js"></script>
+</head>
+
+<body>
+
+<h1>sqlite_async demo</h1>
+
+<main>
+This page is used to test the sqlite_async package on the web.
+Use the console to open and interact with databases.
+
+<pre>
+<code>
+const db = await open('test.db');
+const lock = await write_lock(db);
+release_lock(lock);
+</code>
+</pre>
+</main>
+
+
+</body>
+</html>

--- a/packages/sqlite_async/example/web/main.dart
+++ b/packages/sqlite_async/example/web/main.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:sqlite_async/sqlite_async.dart';
+
+void main() {
+  globalContext['open'] = (String path) {
+    return Future(() async {
+      final db = SqliteDatabase(
+        path: path,
+        options: SqliteOptions(
+          webSqliteOptions: WebSqliteOptions(
+            wasmUri:
+                'https://cdn.jsdelivr.net/npm/@powersync/dart-wasm-bundles@latest/dist/sqlite3.wasm',
+            workerUri: 'worker.dart.js',
+          ),
+        ),
+      );
+      await db.initialize();
+      return db.toJSBox;
+    }).toJS;
+  }.toJS;
+
+  globalContext['write_lock'] = (JSBoxedDartObject db) {
+    final hasLock = Completer<void>();
+    final completer = Completer<void>();
+
+    (db.toDart as SqliteDatabase).writeLock((_) async {
+      print('has write lock!');
+      hasLock.complete();
+      await completer.future;
+    });
+
+    return hasLock.future.then((_) => completer.toJSBox).toJS;
+  }.toJS;
+
+  globalContext['release_lock'] = (JSBoxedDartObject db) {
+    (db.toDart as Completer<void>).complete();
+  }.toJS;
+}

--- a/packages/sqlite_async/example/web/worker.dart
+++ b/packages/sqlite_async/example/web/worker.dart
@@ -1,0 +1,6 @@
+import 'package:sqlite_async/sqlite3_web.dart';
+import 'package:sqlite_async/sqlite3_web_worker.dart';
+
+void main() {
+  WebSqlite.workerEntrypoint(controller: AsyncSqliteController());
+}


### PR DESCRIPTION
When a tab connected to the shared worker holds a mutex while being closed, it's possible for the mutex to still be held in the `AsyncSqliteDatabase` without ever being released.

This tracks which connections hold a mutex and registers a listener when they close to return the mutex. I've tested this manually with a small demo, it's hard to test this automatically since it relies on multiple tabs.