### PR TITLE
Prepare `sqlite_async` version `0.11.7` for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-06-03
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`sqlite_async` - `v0.11.7`](#sqlite_async---v0117)
+
+---
+
+#### `sqlite_async` - `v0.11.7`
+
+- Shared worker: Release locks owned by connected client tab when it closes.
+- Fix web concurrency issues: Consistently apply a shared mutex or let a shared
+  worker coordinate access.
+
 ## 2025-05-28
 
 ---

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.7
+
+- Shared worker: Release locks owned by connected client tab when it closes.
+- Fix web concurrency issues: Consistently apply a shared mutex or let a shared
+  worker coordinate access.
+
 ## 0.11.6
 
 - Native: Consistently report errors when opening the database instead of

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.11.6
+version: 0.11.7
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
This prepares a minor release for `sqlite_async` to fix a few web concurrency issues:

- https://github.com/powersync-ja/sqlite_async.dart/pull/98
- https://github.com/powersync-ja/sqlite_async.dart/pull/97