### PR TITLE
Nested transactions

### DIFF
--- a/packages/sqlite_async/lib/src/impl/context.dart
+++ b/packages/sqlite_async/lib/src/impl/context.dart
@@ -1,0 +1,186 @@
+import 'package:sqlite3/common.dart';
+
+import '../sqlite_connection.dart';
+
+abstract base class UnscopedContext implements SqliteReadContext {
+  Future<ResultSet> execute(String sql, List<Object?> parameters);
+  Future<void> executeBatch(String sql, List<List<Object?>> parameterSets);
+
+  /// Returns an [UnscopedContext] useful as the outermost transaction.
+  ///
+  /// This is called by [ScopedWriteContext.writeTransaction] _after_ executing
+  /// the first `BEGIN` statement.
+  /// This is used on the web to assert that the auto-commit state is false
+  /// before running statements.
+  UnscopedContext interceptOutermostTransaction() {
+    return this;
+  }
+}
+
+final class ScopedReadContext implements SqliteReadContext {
+  final UnscopedContext _context;
+
+  /// Whether this context view is locked on an inner operation like a
+  /// transaction.
+  ///
+  /// We don't use a mutex because we don't want to serialize access - we just
+  /// want to forbid concurrent operations.
+  bool _isLocked = false;
+
+  /// Whether this particular view of a read context has been closed, e.g.
+  /// because the callback owning it has returned.
+  bool _closed = false;
+
+  ScopedReadContext(this._context);
+
+  void _checkNotLocked() {
+    _checkStillOpen();
+
+    if (_isLocked) {
+      throw StateError(
+          'The context from the callback was locked, e.g. due to a nested '
+          'transaction.');
+    }
+  }
+
+  void _checkStillOpen() {
+    if (_closed) {
+      throw StateError('This context to a callback is no longer open. '
+          'Make sure to await all statements on a database to avoid a context '
+          'still being used after its callback has finished.');
+    }
+  }
+
+  @override
+  bool get closed => _closed || _context.closed;
+
+  @override
+  Future<R> computeWithDatabase<R>(
+      Future<R> Function(CommonDatabase db) compute) async {
+    _checkNotLocked();
+    return await _context.computeWithDatabase(compute);
+  }
+
+  @override
+  Future<Row> get(String sql, [List<Object?> parameters = const []]) async {
+    _checkNotLocked();
+    final rows = await getAll(sql, parameters);
+    return rows.first;
+  }
+
+  @override
+  Future<ResultSet> getAll(String sql,
+      [List<Object?> parameters = const []]) async {
+    _checkNotLocked();
+    return await _context.getAll(sql, parameters);
+  }
+
+  @override
+  Future<bool> getAutoCommit() async {
+    _checkStillOpen();
+    return _context.getAutoCommit();
+  }
+
+  @override
+  Future<Row?> getOptional(String sql,
+      [List<Object?> parameters = const []]) async {
+    _checkNotLocked();
+    final rows = await getAll(sql, parameters);
+    return rows.firstOrNull;
+  }
+
+  void invalidate() => _closed = true;
+
+  static Future<T> assumeReadLock<T>(
+    UnscopedContext unsafe,
+    Future<T> Function(SqliteReadContext) callback,
+  ) async {
+    final scoped = ScopedReadContext(unsafe);
+    try {
+      return await callback(scoped);
+    } finally {
+      scoped.invalidate();
+    }
+  }
+}
+
+final class ScopedWriteContext extends ScopedReadContext
+    implements SqliteWriteContext {
+  /// The "depth" of virtual nested transaction.
+  ///
+  /// A value of `0` indicates that this is operating outside of a transaction.
+  /// A value of `1` indicates a regular transaction (guarded with `BEGIN` and
+  /// `COMMIT` statements).
+  /// All higher values indicate a nested transaction implemented with
+  /// savepoint statements.
+  final int transactionDepth;
+
+  ScopedWriteContext(super._context, {this.transactionDepth = 0});
+
+  @override
+  Future<ResultSet> execute(String sql,
+      [List<Object?> parameters = const []]) async {
+    _checkNotLocked();
+    return await _context.execute(sql, parameters);
+  }
+
+  @override
+  Future<void> executeBatch(
+      String sql, List<List<Object?>> parameterSets) async {
+    _checkNotLocked();
+
+    return await _context.executeBatch(sql, parameterSets);
+  }
+
+  @override
+  Future<T> writeTransaction<T>(
+      Future<T> Function(SqliteWriteContext tx) callback) async {
+    _checkNotLocked();
+    final (begin, commit, rollback) = _beginCommitRollback(transactionDepth);
+    ScopedWriteContext? inner;
+
+    try {
+      _isLocked = true;
+
+      await _context.execute(begin, const []);
+      inner =
+          ScopedWriteContext(_context, transactionDepth: transactionDepth + 1);
+      final result = await callback(inner);
+      await _context.execute(commit, const []);
+      return result;
+    } catch (e) {
+      try {
+        await _context.execute(rollback, const []);
+      } catch (e) {
+        // In rare cases, a ROLLBACK may fail.
+        // Safe to ignore.
+      }
+      rethrow;
+    } finally {
+      inner?.invalidate();
+    }
+  }
+
+  static (String, String, String) _beginCommitRollback(int level) {
+    return switch (level) {
+      0 => ('BEGIN IMMEDIATE', 'COMMIT', 'ROLLBACK'),
+      final nested => (
+          'SAVEPOINT s$nested',
+          'RELEASE s$nested',
+          'ROLLBACK TO s$nested'
+        )
+    };
+  }
+
+  static Future<T> assumeWriteLock<T>(
+    UnscopedContext unsafe,
+    Future<T> Function(SqliteWriteContext) callback,
+  ) async {
+    final scoped = ScopedWriteContext(unsafe);
+    try {
+      return await callback(scoped);
+    } finally {
+      scoped.invalidate();
+    }
+  }
+}

--- a/packages/sqlite_async/lib/src/impl/context.dart
+++ b/packages/sqlite_async/lib/src/impl/context.dart
@@ -72,8 +72,7 @@ final class ScopedReadContext implements SqliteReadContext {
   @override
   Future<Row> get(String sql, [List<Object?> parameters = const []]) async {
     _checkNotLocked();
-    final rows = await getAll(sql, parameters);
-    return rows.first;
+    return _context.get(sql, parameters);
   }
 
   @override
@@ -93,8 +92,7 @@ final class ScopedReadContext implements SqliteReadContext {
   Future<Row?> getOptional(String sql,
       [List<Object?> parameters = const []]) async {
     _checkNotLocked();
-    final rows = await getAll(sql, parameters);
-    return rows.firstOrNull;
+    return _context.getOptional(sql, parameters);
   }
 
   void invalidate() => _closed = true;

--- a/packages/sqlite_async/lib/src/impl/context.dart
+++ b/packages/sqlite_async/lib/src/impl/context.dart
@@ -162,6 +162,7 @@ final class ScopedWriteContext extends ScopedReadContext
       }
       rethrow;
     } finally {
+      _isLocked = false;
       inner?.invalidate();
     }
   }

--- a/packages/sqlite_async/lib/src/native/database/native_sqlite_connection_impl.dart
+++ b/packages/sqlite_async/lib/src/native/database/native_sqlite_connection_impl.dart
@@ -138,7 +138,7 @@ class SqliteConnectionImpl
     return _connectionMutex.lock(() async {
       final ctx = _context();
       try {
-        return ScopedReadContext.assumeReadLock(ctx, callback);
+        return await ScopedReadContext.assumeReadLock(ctx, callback);
       } finally {
         await ctx.close();
       }
@@ -161,7 +161,7 @@ class SqliteConnectionImpl
       return await _writeMutex.lock(() async {
         final ctx = _context();
         try {
-          return ScopedWriteContext.assumeWriteLock(ctx, callback);
+          return await ScopedWriteContext.assumeWriteLock(ctx, callback);
         } finally {
           await ctx.close();
         }

--- a/packages/sqlite_async/lib/src/sqlite_queries.dart
+++ b/packages/sqlite_async/lib/src/sqlite_queries.dart
@@ -107,7 +107,7 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout}) async {
     return writeLock((ctx) async {
-      return await internalWriteTransaction(ctx, callback);
+      return ctx.writeTransaction(callback);
     }, lockTimeout: lockTimeout, debugContext: 'writeTransaction()');
   }
 

--- a/packages/sqlite_async/lib/src/utils/shared_utils.dart
+++ b/packages/sqlite_async/lib/src/utils/shared_utils.dart
@@ -21,24 +21,6 @@ Future<T> internalReadTransaction<T>(SqliteReadContext ctx,
   }
 }
 
-Future<T> internalWriteTransaction<T>(SqliteWriteContext ctx,
-    Future<T> Function(SqliteWriteContext tx) callback) async {
-  try {
-    await ctx.execute('BEGIN IMMEDIATE');
-    final result = await callback(ctx);
-    await ctx.execute('COMMIT');
-    return result;
-  } catch (e) {
-    try {
-      await ctx.execute('ROLLBACK');
-    } catch (e) {
-      // In rare cases, a ROLLBACK may fail.
-      // Safe to ignore.
-    }
-    rethrow;
-  }
-}
-
 /// Given a SELECT query, return the tables that the query depends on.
 Future<Set<String>> getSourceTablesText(
     SqliteReadContext ctx, String sql) async {

--- a/packages/sqlite_async/lib/src/web/database.dart
+++ b/packages/sqlite_async/lib/src/web/database.dart
@@ -8,9 +8,9 @@ import 'package:sqlite3_web/sqlite3_web.dart';
 import 'package:sqlite3_web/protocol_utils.dart' as proto;
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:sqlite_async/src/utils/profiler.dart';
-import 'package:sqlite_async/src/utils/shared_utils.dart';
 import 'package:sqlite_async/src/web/database/broadcast_updates.dart';
 import 'package:sqlite_async/web.dart';
+import '../impl/context.dart';
 import 'protocol.dart';
 import 'web_mutex.dart';
 
@@ -95,12 +95,8 @@ class WebDatabase
       {Duration? lockTimeout, String? debugContext}) async {
     if (_mutex case var mutex?) {
       return await mutex.lock(timeout: lockTimeout, () async {
-        final context = _SharedContext(this);
-        try {
-          return await callback(context);
-        } finally {
-          context.markClosed();
-        }
+        return ScopedReadContext.assumeReadLock(
+            _UnscopedContext(this), callback);
       });
     } else {
       // No custom mutex, coordinate locks through shared worker.
@@ -108,7 +104,8 @@ class WebDatabase
           CustomDatabaseMessage(CustomDatabaseMessageKind.requestSharedLock));
 
       try {
-        return await callback(_SharedContext(this));
+        return ScopedReadContext.assumeReadLock(
+            _UnscopedContext(this), callback);
       } finally {
         await _database.customRequest(
             CustomDatabaseMessage(CustomDatabaseMessageKind.releaseLock));
@@ -125,30 +122,24 @@ class WebDatabase
       Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout,
       bool? flush}) {
-    return writeLock(
-        (writeContext) =>
-            internalWriteTransaction(writeContext, (context) async {
-              // All execute calls done in the callback will be checked for the
-              // autocommit state
-              return callback(_ExclusiveTransactionContext(this, writeContext));
-            }),
+    return writeLock((writeContext) {
+      return ScopedWriteContext.assumeWriteLock(
+          _UnscopedContext(this), callback);
+    },
         debugContext: 'writeTransaction()',
         lockTimeout: lockTimeout,
         flush: flush);
   }
 
   @override
-
-  /// Internal writeLock which intercepts transaction context's to verify auto commit is not active
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
       {Duration? lockTimeout, String? debugContext, bool? flush}) async {
     if (_mutex case var mutex?) {
       return await mutex.lock(timeout: lockTimeout, () async {
-        final context = _ExclusiveContext(this);
+        final context = _UnscopedContext(this);
         try {
-          return await callback(context);
+          return await ScopedWriteContext.assumeWriteLock(context, callback);
         } finally {
-          context.markClosed();
           if (flush != false) {
             await this.flush();
           }
@@ -158,11 +149,10 @@ class WebDatabase
       // No custom mutex, coordinate locks through shared worker.
       await _database.customRequest(CustomDatabaseMessage(
           CustomDatabaseMessageKind.requestExclusiveLock));
-      final context = _ExclusiveContext(this);
+      final context = _UnscopedContext(this);
       try {
-        return await callback(context);
+        return await ScopedWriteContext.assumeWriteLock(context, callback);
       } finally {
-        context.markClosed();
         if (flush != false) {
           await this.flush();
         }
@@ -179,17 +169,16 @@ class WebDatabase
   }
 }
 
-class _SharedContext implements SqliteReadContext {
+final class _UnscopedContext extends UnscopedContext {
   final WebDatabase _database;
-  bool _contextClosed = false;
 
   final TimelineTask? _task;
 
-  _SharedContext(this._database)
+  _UnscopedContext(this._database)
       : _task = _database.profileQueries ? TimelineTask() : null;
 
   @override
-  bool get closed => _contextClosed || _database.closed;
+  bool get closed => _database.closed;
 
   @override
   Future<T> computeWithDatabase<T>(
@@ -230,14 +219,6 @@ class _SharedContext implements SqliteReadContext {
     return results.firstOrNull;
   }
 
-  void markClosed() {
-    _contextClosed = true;
-  }
-}
-
-class _ExclusiveContext extends _SharedContext implements SqliteWriteContext {
-  _ExclusiveContext(super.database);
-
   @override
   Future<ResultSet> execute(String sql, [List<Object?> parameters = const []]) {
     return _task.timeAsync('execute', sql: sql, parameters: parameters, () {
@@ -258,15 +239,17 @@ class _ExclusiveContext extends _SharedContext implements SqliteWriteContext {
       });
     });
   }
-}
-
-class _ExclusiveTransactionContext extends _ExclusiveContext {
-  SqliteWriteContext baseContext;
-
-  _ExclusiveTransactionContext(super.database, this.baseContext);
 
   @override
-  bool get closed => baseContext.closed;
+  UnscopedContext interceptOutermostTransaction() {
+    // All execute calls done in the callback will be checked for the
+    // autocommit state
+    return _ExclusiveTransactionContext(_database);
+  }
+}
+
+final class _ExclusiveTransactionContext extends _UnscopedContext {
+  _ExclusiveTransactionContext(super._database);
 
   Future<ResultSet> _executeInternal(
       String sql, List<Object?> parameters) async {

--- a/packages/sqlite_async/test/basic_test.dart
+++ b/packages/sqlite_async/test/basic_test.dart
@@ -189,6 +189,73 @@ void main() {
       );
     });
 
+    group('nested transaction', () {
+      const insert = 'INSERT INTO test_data (description) VALUES(?);';
+      late SqliteDatabase db;
+
+      setUp(() async {
+        db = await testUtils.setupDatabase(path: path);
+        await createTables(db);
+      });
+
+      tearDown(() => db.close());
+
+      test('run in outer transaction', () async {
+        await db.writeTransaction((tx) async {
+          await tx.execute(insert, ['first']);
+
+          await tx.writeTransaction((tx) async {
+            await tx.execute(insert, ['second']);
+          });
+
+          expect(await tx.getAll('SELECT * FROM test_data'), hasLength(2));
+        });
+
+        expect(await db.getAll('SELECT * FROM test_data'), hasLength(2));
+      });
+
+      test('can rollback inner transaction', () async {
+        await db.writeTransaction((tx) async {
+          await tx.execute(insert, ['first']);
+
+          await tx.writeTransaction((tx) async {
+            await tx.execute(insert, ['second']);
+          });
+
+          await expectLater(() async {
+            await tx.writeTransaction((tx) async {
+              await tx.execute(insert, ['third']);
+              expect(await tx.getAll('SELECT * FROM test_data'), hasLength(3));
+              throw 'rollback please';
+            });
+          }, throwsA(anything));
+
+          expect(await tx.getAll('SELECT * FROM test_data'), hasLength(2));
+        });
+
+        expect(await db.getAll('SELECT * FROM test_data'), hasLength(2));
+      });
+
+      test('cannot use outer transaction while inner is active', () async {
+        await db.writeTransaction((outer) async {
+          await outer.writeTransaction((inner) async {
+            await expectLater(outer.execute('SELECT 1'), throwsStateError);
+          });
+        });
+      });
+
+      test('cannot use inner after leaving scope', () async {
+        await db.writeTransaction((tx) async {
+          late SqliteWriteContext inner;
+          await tx.writeTransaction((tx) async {
+            inner = tx;
+          });
+
+          await expectLater(inner.execute('SELECT 1'), throwsStateError);
+        });
+      });
+    });
+
     test('can use raw database instance', () async {
       final factory = await testUtils.testFactory();
       final raw = await factory.openDatabaseForSingleConnection();

--- a/packages/sqlite_async/test/basic_test.dart
+++ b/packages/sqlite_async/test/basic_test.dart
@@ -122,7 +122,7 @@ void main() {
             ['Test Data']);
         expect(rs.rows[0], equals(['Test Data']));
       });
-      expect(await savedTx!.getAutoCommit(), equals(true));
+      expect(await db.getAutoCommit(), equals(true));
       expect(savedTx!.closed, equals(true));
     });
 


### PR DESCRIPTION
This adds support for nested transactions to `sqlite_async`. It does that by:

1. Moving the `writeTransaction` method from the `SqliteConnection` interface to the `SqliteWriteContext` interface.
   - When called on the database, a connection is started with `BEGIN` and `COMMIT`.
   - When called on an existing transaction, savepoints are used to emulate nested transactions.
2. Sharing more parts between web and native:
   - Logic like invalidating a context after its callback has finished was duplicated across platforms, that's now implemented in `context.dart`.
   - This also allows handling transactions there, keeping a counter of nested transactions to generate the correct savepoint and release statements.

A future step will be to bring back nested transactions to `drift_sqlite_async` - but that requires a new API in drift, so it's a follow-up PR.