### PR TITLE
Support 3.8.0 of `package:sqlite3`.

### DIFF
--- a/packages/sqlite_async/lib/src/web/worker/throttled_common_database.dart
+++ b/packages/sqlite_async/lib/src/web/worker/throttled_common_database.dart
@@ -28,12 +28,14 @@ class ThrottledCommonDatabase extends CommonDatabase {
   DatabaseConfig get config => _db.config;
 
   @override
-  void createAggregateFunction<V>(
-      {required String functionName,
-      required AggregateFunction<V> function,
-      AllowedArgumentCount argumentCount = const AllowedArgumentCount.any(),
-      bool deterministic = false,
-      bool directOnly = true}) {
+  void createAggregateFunction<V>({
+    required String functionName,
+    required AggregateFunction<V> function,
+    AllowedArgumentCount argumentCount = const AllowedArgumentCount.any(),
+    bool deterministic = false,
+    bool directOnly = true,
+    bool subtype = false,
+  }) {
     _db.createAggregateFunction(functionName: functionName, function: function);
   }
 
@@ -44,12 +46,14 @@ class ThrottledCommonDatabase extends CommonDatabase {
   }
 
   @override
-  void createFunction(
-      {required String functionName,
-      required ScalarFunction function,
-      AllowedArgumentCount argumentCount = const AllowedArgumentCount.any(),
-      bool deterministic = false,
-      bool directOnly = true}) {
+  void createFunction({
+    required String functionName,
+    required ScalarFunction function,
+    AllowedArgumentCount argumentCount = const AllowedArgumentCount.any(),
+    bool deterministic = false,
+    bool directOnly = true,
+    bool subtype = false,
+  }) {
     _db.createFunction(functionName: functionName, function: function);
   }
 

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - flutter
 
 dependencies:
-  sqlite3: ^2.7.2
+  sqlite3: ^2.8.0
   sqlite3_web: ^0.3.0
   async: ^2.10.0
   collection: ^1.17.0


### PR DESCRIPTION
I've added a new parameter to `createFunction` and `createAggregateFunction` that we need to support in `ThrottledCommonDatabase` as well.