### PR TITLE
Fix distributing table updates from shared worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Packages with breaking changes:
 
 Packages with other changes:
 
+ - [`sqlite_async` - `v0.12.1`](#sqlite_async---v0121)
  - [`sqlite_async` - `v0.12.0`](#sqlite_async---v0120)
  - [`drift_sqlite_async` - `v0.2.3+1`](#drift_sqlite_async---v0231)
 
@@ -25,6 +26,10 @@ Packages with dependency updates only:
  - `drift_sqlite_async` - `v0.2.3+1`
 
 ---
+
+#### `sqlite_async` - `v0.12.1`
+
+- Fix distributing updates from shared worker.
 
 #### `sqlite_async` - `v0.12.0`
 

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1
+
+- Fix distributing updates from shared worker.
+
 ## 0.12.0
 
  - Avoid large transactions creating a large internal update queue.

--- a/packages/sqlite_async/lib/src/native/database/native_sqlite_connection_impl.dart
+++ b/packages/sqlite_async/lib/src/native/database/native_sqlite_connection_impl.dart
@@ -303,7 +303,7 @@ Future<void> _sqliteConnectionIsolateInner(_SqliteConnectionParams params,
   final server = params.portServer;
   final commandPort = ReceivePort();
 
-  db.throttledUpdatedTables.listen((changedTables) {
+  db.updatedTables.listen((changedTables) {
     client.fire(UpdateNotification(changedTables));
   });
 

--- a/packages/sqlite_async/lib/src/utils/shared_utils.dart
+++ b/packages/sqlite_async/lib/src/utils/shared_utils.dart
@@ -133,6 +133,7 @@ extension ThrottledUpdates on CommonDatabase {
         final wrapped = _UpdateListener(listener);
         addListener(wrapped);
 
+        listener.onResume = wrapped.addPending;
         listener.onCancel = () => removeListener(wrapped);
       },
       isBroadcast: true,
@@ -149,6 +150,12 @@ class _UpdateListener {
   void notify(Set<String> pendingUpdates) {
     buffered.addAll(pendingUpdates);
     if (!downstream.isPaused) {
+      addPending();
+    }
+  }
+
+  void addPending() {
+    if (buffered.isNotEmpty) {
       downstream.add(buffered);
       buffered = {};
     }

--- a/packages/sqlite_async/lib/src/utils/shared_utils.dart
+++ b/packages/sqlite_async/lib/src/utils/shared_utils.dart
@@ -154,12 +154,3 @@ class _UpdateListener {
     }
   }
 }
-
-extension StreamUtils<T> on Stream<T> {
-  Stream<T> pauseAfterEvent(Duration duration) async* {
-    await for (final event in this) {
-      yield event;
-      await Future.delayed(duration);
-    }
-  }
-}

--- a/packages/sqlite_async/lib/src/web/worker/worker_utils.dart
+++ b/packages/sqlite_async/lib/src/web/worker/worker_utils.dart
@@ -56,7 +56,8 @@ class AsyncSqliteDatabase extends WorkerDatabase {
   final Map<ClientConnection, _ConnectionState> _state = {};
 
   AsyncSqliteDatabase({required this.database})
-      : _updates = database.throttledUpdatedTables;
+      : _updates = database.updatedTables
+            .pauseAfterEvent(const Duration(milliseconds: 1));
 
   _ConnectionState _findState(ClientConnection connection) {
     return _state.putIfAbsent(connection, _ConnectionState.new);

--- a/packages/sqlite_async/pubspec.yaml
+++ b/packages/sqlite_async/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.12.0
+version: 0.12.1
 repository: https://github.com/powersync-ja/sqlite_async.dart
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
In https://github.com/powersync-ja/sqlite_async.dart/pull/105, the `throttledUpdatedTables` stream was shared between different connections connecting to a database worker. That's a problem, because the've been implemented as a single-subscription stream, so only the first subscription would have been successful.

This:

1. Replaces `throttledUpdatedTables` with a non-throttled variant that supports multiple subscriptions. The stream can still be throttled by pausing the subscription, which will emit items into a pending set internally.
2. On native platforms, removes the throttle entirely. Sending isolate messages isn't that expensive, we only do it once per transaction, and there's still the regular throttling logic for watched queries downstream.
3. On the web, we pause the subscription while the client is busy handling the notification, giving us backpressure support without a fixed delay after each message.

I've tested `package:powersync_core` web tests with these changes and also ran a demo app with this to ensure it works.