### PR TITLE
Remove legacy skip in tests

### DIFF
--- a/packages/drift_sqlite_async/test/basic_test.dart
+++ b/packages/drift_sqlite_async/test/basic_test.dart
@@ -183,7 +183,7 @@ void main() {
             {'description': 'Test 1'},
             {'description': 'Test 3'}
           ]));
-    }, skip: 'sqlite_async does not support nested transactions');
+    });
 
     test('Concurrent select', () async {
       var completer1 = Completer<void>();


### PR DESCRIPTION
Remove legacy skip. It now supports nested transactions