### PR TITLE
Run CI for PRs, fix format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,13 +3,15 @@ name: Test
 on:
   push:
     branches:
-      - "**"
+      - "*"
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)  
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: dart-lang/setup-dart@v1
 
       - name: Install Melos
@@ -29,6 +31,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)  
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +52,7 @@ jobs:
             sqlite_url: "https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz"
             dart_sdk: stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.dart_sdk }}

--- a/packages/drift_sqlite_async/test/generated/database.dart
+++ b/packages/drift_sqlite_async/test/generated/database.dart
@@ -15,7 +15,7 @@ class TodoItems extends Table {
 @DriftDatabase(tables: [TodoItems])
 class TodoDatabase extends _$TodoDatabase {
   TodoDatabase(SqliteConnection db) : super(SqliteAsyncDriftConnection(db));
-  
+
   TodoDatabase.fromSqliteAsyncConnection(SqliteAsyncDriftConnection super.conn);
 
   @override


### PR DESCRIPTION
This fixes the formatting issue currently failing the CI on `main`. To avoid it in the future, it also enables the CI to run for pull requests.