### PR TITLE
Release `drift_sqlite_async` package as well

### DIFF
--- a/packages/drift_sqlite_async/CHANGELOG.md
+++ b/packages/drift_sqlite_async/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-wip.0
+## 0.3.0
 
 - Support versions 3.x of the `sqlite3` package.
 

--- a/packages/drift_sqlite_async/pubspec.yaml
+++ b/packages/drift_sqlite_async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: drift_sqlite_async
-version: 0.3.0-wip.0
+version: 0.3.0
 homepage: https://github.com/powersync-ja/sqlite_async.dart
 repository: https://github.com/powersync-ja/sqlite_async.dart
 description: Use Drift with a sqlite_async database, allowing both to be used in the same application.
@@ -18,7 +18,7 @@ environment:
 dependencies:
   drift: ">=2.28.0 <3.0.0"
   sqlite3: ^3.2.0
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/packages/sqlite_async/CHANGELOG.md
+++ b/packages/sqlite_async/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 0.14.0
 
-__Note__: This version of `sqlite_async` is still in development and there might be additional
-API changes between this release and the final `0.14.0` version. This release is mostly meant for
-internal testing.
-
 - Support versions 3.x of the `sqlite3` package and 0.7.x of `sqlite3_web`.
 - Remove the `sqlite3_open.dart` library, SQLite libraries are no longer loaded through Dart.
 - __Breaking__: Rewrite the native connection pool implementation.


### PR DESCRIPTION
This removes the `-wip` suffix from `drift_sqlite_async` and an outdated warning about those versions still being worked on (I should have done both of that in #138...).